### PR TITLE
Only upload binaries for builds on "main" branch

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -32,6 +32,7 @@ jobs:
         export CI=azure
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export UPLOAD_ON_BRANCH="main"
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
           export IS_PR_BUILD="True"
         else

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -23,6 +23,7 @@ jobs:
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export UPLOAD_ON_BRANCH="main"
       if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
         export IS_PR_BUILD="True"
       else

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -12,3 +12,4 @@ build_platform:
 conda_forge_output_validation: true
 test_on_native_only: true
 # build_with_mambabuild: false
+upload_on_branch: main


### PR DESCRIPTION
Motivation: Maintainers want to be able to easily run CI on experimental changes in branches (running the CI on your fork requires setting up your own Azure infrastructure). We may also add a branch to run nightly builds

Documentation: https://conda-forge.org/docs/maintainer/conda_forge_yml.html#upload-on-branch

CC: @johnkerl @Shelnutt2 

Note that this is a pure feedstock infrastructure update, so there's no need to modify the recipe