### PR TITLE
Add GitHub Actions pipeline that triggers a nightly feedstock build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,44 @@
+# This pipeline runs nightly. It updates the recipe to build the latest commit
+# from "main" in the TileDB-SOMA repo, and force pushes to the branch
+# "nightly-build", which triggers the feedstock builds on Azure. Because
+# `upload_on_branch: main` is set in `conda-forge.yml`, any binaries produced by
+# this nightly test build are never uploaded to anaconda.org
+name: Trigger nightly build
+on:
+  push:
+    paths:
+      - '.github/workflows/nightly.yml'
+  schedule:
+     - cron: "27 1 * * *" # Every night at 1:27 AM UTC (8:27 PM EST; 9:27 PM EDT)
+  workflow_dispatch:
+jobs:
+  nightly:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update recipe source to use Git repo
+        run: |
+          # append "-nightly" to version string
+          sed -i \
+            s/"{% set version = \"\(.*\)\" %}"/"{% set version = \"\\1-nightly\" %}"/ \
+            recipe/meta.yaml
+
+          # Use Git URL as source
+          sed -i \
+            s/"url: https:\/\/github.com\/single-cell-data\/TileDB-SOMA\/archive\/{{ version }}.tar.gz"/"git_url: https:\/\/github.com\/single-cell-data\/TileDB-SOMA.git"/ \
+            recipe/meta.yaml
+
+          # Build the latest commit on "main" branch
+          sed -i \
+            s/"sha256: .\+"/"git_rev: main\n  git_depth: 1"/ \
+            recipe/meta.yaml
+
+          git --no-pager diff recipe/meta.yaml
+      - name: Push update to GitHub
+        run: |
+          git config --local user.name "GitHub Actions"
+          git config --local user.email "runneradmin@github.com"
+          git commit -am "Nightly build"
+          git push --force origin HEAD:nightly-build


### PR DESCRIPTION
This pipeline runs nightly. It updates the recipe to build the latest commit from "main" in the TileDB-SOMA repo, and force pushes to the branch "nightly-build", which triggers the feedstock builds on Azure. Because `upload_on_branch: main` is set in `conda-forge.yml`, any binaries produced by this nightly test build are never uploaded to anaconda.org

Other details:

* "-nightly" is appended to the version string. This makes it easier to read the logs, and also ensures that the Python client always builds against the locally built libtiledbsoma
* The pipeline runs every night, but can also be manually triggered in the Actions UI or by editing the workflow file

You can see how this works on my fork:

* [nightly-build branch](https://github.com/jdblischak/tiledbsoma-feedstock/tree/nightly-build)
* [nightly actions](https://github.com/jdblischak/tiledbsoma-feedstock/actions/workflows/nightly.yml)
* [example commit](https://github.com/jdblischak/tiledbsoma-feedstock/commit/9d86f492f79ec0338a432038819fc26ffd393930) - this gets overwritten each run of the pipeline
* [example Azure build logs](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=221&view=results)

Note that the builds are currently failing because the conda recipe uses the flag `--libtiledbsoma` to build the Python client, and that flag was removed from "main" in PR https://github.com/single-cell-data/TileDB-SOMA/pull/1189

Potential improvements if requested:
* Move the code in the pipeline steps to standalone scripts for easier local troubleshooting
* Automatically open an Issue if the nightly build fails. This is tricky since it requires cross-communication between the Azure builds and a GitHub pipeline (I don't want to directly edit the conda-forge generated Azure files since these will be overwritten by future conda smithy rerenderings). Also this is bound to be noisy since any breaking change will fail until a new release is made
* Fancier version string, eg append the current date