### PR TITLE
Fix version string for nightly build

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,15 +14,21 @@ on:
 jobs:
   nightly:
     runs-on: ubuntu-latest
+    env:
+      TZ: "America/New_York"
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Update recipe source to use Git repo
         run: |
-          # append "-nightly" to version string
+          # append the date (.devYYYYMMDD) to version string
+          # has to follow conda recipe rules (no dashes) and PEP 440 (enforced by setuptools)
+          # https://peps.python.org/pep-0440/
+          # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html?highlight=recipe%20meta.yaml#package-version
+          the_date="$(date +%Y%m%d)"
           sed -i \
-            s/"{% set version = \"\(.*\)\" %}"/"{% set version = \"\\1-nightly\" %}"/ \
+            s/"{% set version = \"\(.*\)\" %}"/"{% set version = \"\\1.dev${the_date}\" %}"/ \
             recipe/meta.yaml
 
           # Use Git URL as source


### PR DESCRIPTION
Followup to PR #12. Embarrassingly I must have somehow got lost in the various Azure builds, and didn't notice that I used an invalid version string for conda recipes. This PR updates the version string for the nightly builds to satisfy both conda and setuptools requirements:

* [conda](https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html?highlight=recipe%20meta.yaml#package-version): cannot include dashes
* setuptools: must adhere to [PEP 440](https://peps.python.org/pep-0440/)

I went with X.X.X.devYYYYMMDD, but I'm open to other options that satisfy the requirements. Note that X.X.X corresponds to the latest version in the conda recipe. It's possible to instead use the current version string in the upstream Git repo, but I'm trying to avoid prematurely optimizing this nightly build pipeline.

Here are the relevant Azure logs from my fork:

* [builds on branch "nightly-build"](https://dev.azure.com/jdblischak/feedstock-builds/_build?definitionId=7&_a=summary&repositoryFilter=7&branchFilter=39%2C39%2C39%2C39%2C39%2C39%2C39%2C39%2C39%2C39)
* [build log that passed before I opened this PR](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=227&view=results) - note the use of the version string `1.2.1.dev20230417`
* [build log (currently running) from squash commit](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=229&view=results)

