### PR TITLE
Pre-release test for TileDB-SOMA 1.2.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,8 +18,7 @@ package:
 # Pre-release canary "will Conda be green if we release":
 source:
   git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  #git_rev: 4f67de4d7f9aceade5aca77f1f517e87c1929eec
-  git_rev: release-1.2.3
+  git_rev: 313ff1ed3b31b94119748ef288ac17f806723492
   git_depth: 1
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,11 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.15.3,<2.16
+        - tiledb >=2.15.2,<2.16
         - spdlog
         - fmt
       run:
-        - tiledb >=2.15.3,<2.16
+        - tiledb >=2.15.2,<2.16
         - spdlog
         - fmt
   - name: tiledbsoma-py

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,20 +12,20 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 # Pre-release canary "will Conda be green if we release":
-# source:
-#   git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#   git_rev: 00commithashyouwanttotest00commithashyouwanttotest00
-#   git_depth: 1
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: 4f67de4d7f9aceade5aca77f1f517e87c1929eec
+  git_depth: 1
 
 
 build:
   number: 0
   skip: true  # [win or linux32 or py2k]
-# Important: set this back to 0 on a new release
+# Important: set this build number back to 0 on a new release
 
 outputs:
   - name: libtiledbsoma

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,8 @@ package:
 # Pre-release canary "will Conda be green if we release":
 source:
   git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  git_rev: 4f67de4d7f9aceade5aca77f1f517e87c1929eec
+  #git_rev: 4f67de4d7f9aceade5aca77f1f517e87c1929eec
+  git_rev: release-1.2.3
   git_depth: 1
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,7 +23,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this build number back to 0 on a new release
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,11 +39,11 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb 2.15.*
+        - tiledb >=2.15.3,<2.16
         - spdlog
         - fmt
       run:
-        - tiledb 2.15.*
+        - tiledb >=2.15.3,<2.16
         - spdlog
         - fmt
   - name: tiledbsoma-py
@@ -77,7 +77,7 @@ outputs:
         - scipy
         - anndata       # [py>37]
         - anndata <0.9  # [py<=37]
-        - tiledb-py 0.21.*
+        - tiledb-py >=0.21.3,<0.22.0
         - typing-extensions
         - numba
         - attrs


### PR DESCRIPTION
Not to be merged. Just a check for "is the putative TileDB-SOMA 1.2.3 Conda-CI green?".