### PR TITLE
Rerender and upload nightly binaries

### DIFF
--- a/.github/scripts/nightly/add-and-commit.sh
+++ b/.github/scripts/nightly/add-and-commit.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eux
+
+git config --local user.name "GitHub Actions"
+git config --local user.email "runneradmin@github.com"
+git commit -am "Nightly build"
+

--- a/.github/scripts/nightly/update-feedstock.sh
+++ b/.github/scripts/nightly/update-feedstock.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux
+
+# Allow uploads on branch "nightly-build"
+sed -i \
+  s/"upload_on_branch: main"/"upload_on_branch: nightly-build"/ \
+  conda-forge.yml
+
+# Use label "nightlies"
+sed -i \
+  s/"tiledb main"/"tiledb nightlies"/ \
+  recipe/conda_build_config.yaml
+
+# Print differences
+git --no-pager diff conda-forge.yml recipe/conda_build_config.yaml

--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -eux
+
+# append the date (.devYYYYMMDD) to version string
+# has to follow conda recipe rules (no dashes) and PEP 440 (enforced by setuptools)
+# https://peps.python.org/pep-0440/
+# https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html?highlight=recipe%20meta.yaml#package-version
+the_date="$(date +%Y%m%d)"
+sed -i \
+  s/"{% set version = \"\(.*\)\" %}"/"{% set version = \"\\1.dev${the_date}\" %}"/ \
+  recipe/meta.yaml
+
+# Use Git URL as source
+sed -i \
+  s/"url: https:\/\/github.com\/single-cell-data\/TileDB-SOMA\/archive\/{{ version }}.tar.gz"/"git_url: https:\/\/github.com\/single-cell-data\/TileDB-SOMA.git"/ \
+  recipe/meta.yaml
+
+# Build the latest commit on "main" branch
+sed -i \
+  s/"sha256: .\+"/"git_rev: main\n  git_depth: 1"/ \
+  recipe/meta.yaml
+
+git --no-pager diff recipe/meta.yaml

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,30 +21,22 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Update recipe source to use Git repo
-        run: |
-          # append the date (.devYYYYMMDD) to version string
-          # has to follow conda recipe rules (no dashes) and PEP 440 (enforced by setuptools)
-          # https://peps.python.org/pep-0440/
-          # https://docs.conda.io/projects/conda-build/en/latest/resources/define-metadata.html?highlight=recipe%20meta.yaml#package-version
-          the_date="$(date +%Y%m%d)"
-          sed -i \
-            s/"{% set version = \"\(.*\)\" %}"/"{% set version = \"\\1.dev${the_date}\" %}"/ \
-            recipe/meta.yaml
-
-          # Use Git URL as source
-          sed -i \
-            s/"url: https:\/\/github.com\/single-cell-data\/TileDB-SOMA\/archive\/{{ version }}.tar.gz"/"git_url: https:\/\/github.com\/single-cell-data\/TileDB-SOMA.git"/ \
-            recipe/meta.yaml
-
-          # Build the latest commit on "main" branch
-          sed -i \
-            s/"sha256: .\+"/"git_rev: main\n  git_depth: 1"/ \
-            recipe/meta.yaml
-
-          git --no-pager diff recipe/meta.yaml
+        run: bash .github/scripts/nightly/update-recipe.sh
+      - name: Update feedstock
+        run: bash .github/scripts/nightly/update-feedstock.sh
+      - name: Add and commit
+        run: bash .github/scripts/nightly/add-and-commit.sh
+      - name: Install conda-smithy to rerender
+        uses: mamba-org/provision-with-micromamba@main
+        with:
+          environment-file: false
+          environment-name: env
+          extra-specs: conda-smithy
+          channels: conda-forge
+          cache-env: true
+      - name: Rerender feedstock
+        shell: bash -l {0}
+        run: conda smithy rerender --commit auto
       - name: Push update to GitHub
-        run: |
-          git config --local user.name "GitHub Actions"
-          git config --local user.email "runneradmin@github.com"
-          git commit -am "Nightly build"
-          git push --force origin HEAD:nightly-build
+        # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/tiledbsoma-feedstock' && github.event_name != 'pull_request' }}
+        run: git push --force origin HEAD:nightly-build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,5 +38,5 @@ jobs:
         shell: bash -l {0}
         run: conda smithy rerender --commit auto
       - name: Push update to GitHub
-        # if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/tiledbsoma-feedstock' && github.event_name != 'pull_request' }}
+        if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/tiledbsoma-feedstock' && github.event_name != 'pull_request' }}
         run: git push --force origin HEAD:nightly-build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 # This pipeline runs nightly. It updates the recipe to build the latest commit
 # from "main" in the TileDB-SOMA repo, and force pushes to the branch
-# "nightly-build", which triggers the feedstock builds on Azure. Because
-# `upload_on_branch: main` is set in `conda-forge.yml`, any binaries produced by
-# this nightly test build are never uploaded to anaconda.org
+# "nightly-build", which triggers the feedstock builds on Azure. It also sets
+# `upload_on_branch` in `conda-forge.yml` to "nightly-build" and rerenders, so the
+# binaries are uploaded to anaconda.org
 name: Trigger nightly build
 on:
   push:


### PR DESCRIPTION
This updates the existing nightly builds to upload the conda binaries that are created. It labels the binaries with the tag "nightlies" so that normal end users are not affected. Developers can install the nightly conda binaries by specyfing the channel `-c "tiledb/label/nightlies"` when installing with conda.

You can see the example commits it creates on my fork:

* [nightly-build branch](https://github.com/jdblischak/tiledbsoma-feedstock/tree/nightly-build)
* [example commit that updates recipe and feedstock files](https://github.com/jdblischak/tiledbsoma-feedstock/commit/85610d37f9afe2840216be2c3525b9a96ca7c83d)
* [example commit that rerenders feedstock](https://github.com/jdblischak/tiledbsoma-feedstock/commit/22b4e8011be6505e5b416fc909a5ed56268178cf) - note that it changes the upload branch in the CI files

However, all builds (nightly, main branch) are currently failing to build the Python client due to a solver error. This is currently being discussed in PR #18
