### PR TITLE
Add back top-level about section (required for rerendering)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@ About tiledbsoma-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/main/LICENSE.txt)
 
+About tiledbsoma
+----------------
+
 Home: http://tiledb.com
 
 Package license: MIT
@@ -10,6 +13,48 @@ Package license: MIT
 Summary: TileDB-SOMA API
 
 Development: https://github.com/single-cell-data/TileDB-SOMA
+
+Documentation: https://docs.tiledb.com/
+
+Efficient storage and retrieval of single-cell data using TileDB
+About libtiledbsoma
+-------------------
+
+Home: http://tiledb.com
+
+Package license: MIT
+
+Summary: TileDB-SOMA C++ library
+
+Development: https://github.com/single-cell-data/TileDB-SOMA
+
+Documentation: https://docs.tiledb.com/
+
+SOMA - for "Stack Of Matrices, Annotated" - is a flexible, extensible, and open-source API enabling access to data in a variety of formats. The driving use case of SOMA is for single-cell data in the form of annotated matrices where observations are frequently cells and features are genes, proteins, or genomic regions.
+About r-tiledbsoma
+------------------
+
+Home: http://tiledb.com
+
+Package license: MIT
+
+Summary: TileDB-SOMA R API
+
+Development: https://github.com/single-cell-data/TileDB-SOMA/tree/main/apis/r
+
+Documentation: https://docs.tiledb.com/
+
+R API for efficient storage and retrieval of single-cell data using TileDB
+About tiledbsoma-py
+-------------------
+
+Home: http://tiledb.com
+
+Package license: MIT
+
+Summary: TileDB-SOMA Python API
+
+Development: https://github.com/single-cell-data/TileDB-SOMA/tree/main/apis/python
 
 Documentation: https://docs.tiledb.com/
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,7 +53,7 @@ outputs:
       license: MIT
       license_family: MIT
       license_file: LICENSE
-      summary: 'TileDB-SOMA C++ library'
+      summary: TileDB-SOMA C++ library
       description: >-
         SOMA - for "Stack Of Matrices, Annotated" - is a flexible, extensible,
         and open-source API enabling access to data in a variety of formats. The
@@ -112,8 +112,8 @@ outputs:
       license: MIT
       license_family: MIT
       license_file: LICENSE
-      summary: 'TileDB-SOMA Python API'
-      description: 'Python API for efficient storage and retrieval of single-cell data using TileDB'
+      summary: TileDB-SOMA Python API
+      description: Python API for efficient storage and retrieval of single-cell data using TileDB
       doc_url: https://docs.tiledb.com/
       dev_url: https://github.com/single-cell-data/TileDB-SOMA/tree/main/apis/python
   - name: r-tiledbsoma
@@ -186,10 +186,20 @@ outputs:
       license_file:
         - '{{ environ["PREFIX"] }}/lib/R/share/licenses/MIT'
         - apis/r/LICENSE
-      summary: 'TileDB-SOMA R API'
-      description: 'R API for efficient storage and retrieval of single-cell data using TileDB'
+      summary: TileDB-SOMA R API
+      description: R API for efficient storage and retrieval of single-cell data using TileDB
       doc_url: https://docs.tiledb.com/
       dev_url: https://github.com/single-cell-data/TileDB-SOMA/tree/main/apis/r
+
+about:
+  home: http://tiledb.com
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE
+  summary: TileDB-SOMA API
+  description: Efficient storage and retrieval of single-cell data using TileDB
+  doc_url: https://docs.tiledb.com/
+  dev_url: https://github.com/single-cell-data/TileDB-SOMA
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
In PR #24, I removed the top-level about section in favor of separate about sections per output. This added some redundancy (which we could probably solve with some YAML/jinja2 hacking if we really wanted to), but had the big benefit of having accurate summary and description sections on anaconda.org.

While the top-level about section isn't required for conda, it is required by `conda smithy rerender` to populate the README. This is why the [nightly builds are currently failing](https://github.com/TileDB-Inc/tiledbsoma-feedstock/actions/workflows/nightly.yml), eg [build #58 from 2 days ago](https://github.com/TileDB-Inc/tiledbsoma-feedstock/actions/runs/5195173018/jobs/9367627772).

Note that the README rendering for a recipe with multiple outputs is rather unfortunate. There is no newline between the description of the previous output and the title of the next output section, so the whole description is formatted as a header. I tried some quick hacks, eg adding `\n` to the description, but nothing worked. This appears to happen for all recipes with multiple outputs, eg https://github.com/conda-forge/arrow-cpp-feedstock#readme. I'll take a quick look at conda-smithy to see if there is a quick fix

Please feel free to suggest changes to the summary and descriptions

Also note that I purposefully did _not_ bump the build number. This PR only affects the feedstock and not the builds, so there is no reason to waste storage space by uploading new binaries.

