### PR TITLE
Fully specify attrs dependency.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -25,7 +25,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 
@@ -99,7 +99,7 @@ outputs:
         - tiledb-py >=0.21.3,<0.22.0
         - typing-extensions >=4.1
         - numba
-        - attrs
+        - attrs >=22.2
         - somacore >=1.0.3
         - scanpy 1.9.*
     test:


### PR DESCRIPTION
We use features from recent versions of attrs, but did not specify that we needed this version. In an environment that, for whatever reason, had an earlier version installed, this would cause importing tiledbsoma to fail.