### PR TITLE
TileDB-SOMA 1.2.6 pre-release check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.2.5" %}
+{% set version = "1.2.6" %}
 {% set version_r = "0.0.0.9024" %}
-{% set sha256 = "0eb5b44f0a786d3089fb4ce7ee5d5c4ee6df1c7cacaa8a77f11bde95c1b244ce" %}
+{% set sha256 = "this-is-tbd-see-below" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -13,19 +13,19 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-# Pre-release canary "will Conda be green if we release":
 #source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: db2782bad8b11f7eb0899d0a8b78118c6b5a49a2
-#  git_depth: 1
-#  # hoping to be 1.2.4
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
+# Pre-release canary "will Conda be green if we release":
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: 1c085c51eef6f7b849e6cd3def151afbc5a5ca47 # release-1.2 tip as of 2023-06-20
+  git_depth: 1
+  # hoping to be 1.2.6
 
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -20,7 +20,7 @@ package:
 source:
   git_url: https://github.com/single-cell-data/TileDB-SOMA.git
   git_rev: 1c085c51eef6f7b849e6cd3def151afbc5a5ca47 # release-1.2 tip as of 2023-06-20
-  git_depth: 1
+  git_depth: -1
   # hoping to be 1.2.6
 
 


### PR DESCRIPTION
Following our currently established procedure at
https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases

As always (please see the above wiki) this isn't to _be_ released but rather to check the _feasibility_ of tagging a release.

Food for thought: The four PRs at the tip of https://github.com/single-cell-data/TileDB-SOMA/commits/release-1.2 as of today are all app-level -- and as such shouldn't affect package pins -- _except_ for https://github.com/single-cell-data/TileDB-SOMA/pull/1484/files. That PR affects the `numba` pin, only for Python 3.11: from 0.57.0rc1 to 0.57.0. However, in this repo's `recipe/meta.yaml` we have no `numba` constraints so I don't understand what we do or do not need to do new here.

Another note: I haven't re-renedered yet but I will attempt to check to see if we need to re-render.