### PR TITLE
Enable flexible channel priority to install tiledb::tiledb-py for py37

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -17,3 +17,6 @@ azure:
   build_id: 43
   user_or_org: TileDB-Inc
   project_name: CI
+# Temporarily required to install tiledb-py with Python 3.7,
+# which is only being built on the "tiledb" channel
+channel_priority: flexible


### PR DESCRIPTION
There are currently 2 issues that are breaking the linux-64 Python 3.7 [nightly builds](https://dev.azure.com/TileDB-Inc/CI/_build?definitionId=43&_a=summary&repositoryFilter=39&branchFilter=8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732) on the [nightly-build branch](https://github.com/TileDB-Inc/tiledbsoma-feedstock/tree/nightly-build):

1. The conda solver is unable to install tiledbsoma-py/libtiledbsoma/tiledb-py/libtiledb in a Python 3.7 environment, so conda is unable to install the run time dependencies for the test section of the recipe. This conda solver error first started back on [2023-06-26](https://dev.azure.com/TileDB-Inc/CI/_build/results?buildId=32887&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d). I believe the problem is the strict channel priority, which by default prefers older packages in a higher-priority channel (in this case conda-forge, which only has older tiledb-py available for Python 3.7) over the newer packages available in lower-priority channel (in this case tiledb, because we only build for Python 3.7 in the TileDB-Inc feedstock fork). This PR updates the feedstock to use [flexible channel priority](https://conda-forge.org/docs/maintainer/conda_forge_yml.html#channel-priority), which fixes this problem. Once we no longer need to build for Python 3.7, we should switch back to strict channel priority, since in general this ensures more stable environments

1. While fixing the above Issue, I discovered that the recently updated `zipp-feedstock` has broken the build step (it's a dependency of setuptools) because [zipp dropped support for Python 3.7](https://github.com/jaraco/zipp/commit/4269d2771a1cd7aaf5b365a0108dcef5a3c029d6). This is currently being fixed (https://github.com/conda-forge/zipp-feedstock/issues/42, https://github.com/conda-forge/zipp-feedstock/pull/43), but this PR will fail until the fix is deployed. However, I tested in my fork by temporarily setting `zipp <3.16` to confirm that the flexible channel priority fixes the conda solver error





xref: https://github.com/TileDB-Inc/somacore-feedstock/pull/4