### PR TITLE
tiledbsoma 1.3.0

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -34,7 +34,6 @@ python:
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 r_base:
-- '4.1'
 - '4.2'
 spdlog:
 - '1.11'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -34,7 +34,6 @@ python:
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 r_base:
-- '4.1'
 - '4.2'
 spdlog:
 - '1.11'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -32,7 +32,6 @@ python:
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 r_base:
-- '4.1'
 - '4.2'
 spdlog:
 - '1.11'

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -55,11 +55,6 @@ source run_conda_forge_build_setup
 echo -e "\n\nMaking the build clobber file"
 make_build_number ./ ./recipe ./.ci_support/${CONFIG}.yaml
 
-if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
-    EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
-fi
-
-
 if [[ -f LICENSE.txt ]]; then
   cp LICENSE.txt "recipe/recipe-scripts-license.txt"
 fi
@@ -75,6 +70,11 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
+
+    if [[ "${HOST_PLATFORM}" != "${BUILD_PLATFORM}" ]]; then
+        EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
+    fi
+
     conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ About tiledbsoma-feedstock
 
 Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/main/LICENSE.txt)
 
+
 About tiledbsoma
 ----------------
 
@@ -17,6 +18,7 @@ Development: https://github.com/single-cell-data/TileDB-SOMA
 Documentation: https://docs.tiledb.com/
 
 Efficient storage and retrieval of single-cell data using TileDB
+
 About libtiledbsoma
 -------------------
 
@@ -31,6 +33,7 @@ Development: https://github.com/single-cell-data/TileDB-SOMA
 Documentation: https://docs.tiledb.com/
 
 SOMA - for "Stack Of Matrices, Annotated" - is a flexible, extensible, and open-source API enabling access to data in a variety of formats. The driving use case of SOMA is for single-cell data in the form of annotated matrices where observations are frequently cells and features are genes, proteins, or genomic regions.
+
 About r-tiledbsoma
 ------------------
 
@@ -45,6 +48,7 @@ Development: https://github.com/single-cell-data/TileDB-SOMA/tree/main/apis/r
 Documentation: https://docs.tiledb.com/
 
 R API for efficient storage and retrieval of single-cell data using TileDB
+
 About tiledbsoma-py
 -------------------
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.2.7" %}
-{% set version_r = "0.0.0.9024" %}
-{% set sha256 = "58942b6a6c6a6a6b153c58c4879596d32dbe7b0551f44c635e297633fba62f0b" %}
+{% set version = "1.3.0" %}
+{% set version_r = "0.99.0" %}
+{% set sha256 = "1fb5bf86440a47b724ffb083143bda8a26d79e036336bac57ac7c1feaa5d4b9d" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,12 +16,13 @@ package:
 source:
   url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
   sha256: {{ sha256 }}
+
 # Pre-release canary "will Conda be green if we release":
 #source:
 #  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: db2782bad8b11f7eb0899d0a8b78118c6b5a49a2
+#  git_rev: 02d45e92865a152535f2a30f247eec081e447041
 #  git_depth: -1
-#  # hoping to be 1.2.4
+#  # hoping to be 1.3.0-rc0
 
 
 build:
@@ -41,11 +42,11 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.15.2,<2.16
+        - tiledb >=2.16.0,<2.17
         - spdlog
         - fmt
       run:
-        - tiledb >=2.15.2,<2.16
+        - tiledb >=2.16.0,<2.17
         - spdlog
         - fmt
     about:
@@ -96,7 +97,7 @@ outputs:
         - scipy
         - anndata       # [py>37]
         - anndata <0.9  # [py<=37]
-        - tiledb-py >=0.21.3,<0.22.0
+        - tiledb-py >=0.22.0,<0.23.0
         - typing-extensions >=4.1
         - numba
         - attrs >=22.2
@@ -132,7 +133,7 @@ outputs:
         - r-rcppspdlog               # [build_platform != target_platform]
         - r-matrix                   # [build_platform != target_platform]
         - r-bit64                    # [build_platform != target_platform]
-        - r-tiledb >=0.19.1          # [build_platform != target_platform]
+        - r-tiledb >=0.20.0          # [build_platform != target_platform]
         - r-arrow                    # [build_platform != target_platform]
         - r-fs                       # [build_platform != target_platform]
         - r-glue                     # [build_platform != target_platform]
@@ -147,7 +148,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64
-        - r-tiledb >=0.19.1
+        - r-tiledb >=0.20.0
         - r-arrow
         - r-fs
         - r-glue
@@ -163,7 +164,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64
-        - r-tiledb >=0.19.1
+        - r-tiledb >=0.20.0
         - r-arrow
         - r-fs
         - r-glue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
 {% set version = "1.3.0" %}
-{% set version_r = "0.99.0" %}
+{% set version_r = "0.99.1" %}
 {% set sha256 = "1fb5bf86440a47b724ffb083143bda8a26d79e036336bac57ac7c1feaa5d4b9d" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz


### PR DESCRIPTION
Following our release procedure at https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases, as #34 passed Conda pre-check and https://github.com/single-cell-data/TileDB-SOMA/releases/tag/1.3.0 has been tagged