### PR TITLE
Loosen pyarrow pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 
@@ -73,7 +73,7 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
-        - pyarrow 9.0.*                          # [build_platform != target_platform]
+        - pyarrow                                # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
       host:
         - python
@@ -87,12 +87,12 @@ outputs:
         - setuptools_scm
         - wheel
         - numpy
-        - pyarrow 9.0.*
+        - pyarrow
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - pandas
-        - pyarrow 9.0.*
+        - pyarrow
         - python
         - scipy
         - anndata       # [py>37]


### PR DESCRIPTION
 TileDB-SOMA doesn't require a particular version of pyarrow because it does not link against any libarrow library directly.

x-ref: https://github.com/TileDB-Inc/tiledb-vcf-feedstock/pull/91