### PR TITLE
Always clean up Python and C++ builds

### DIFF
--- a/recipe/build-libtiledbsoma.sh
+++ b/recipe/build-libtiledbsoma.sh
@@ -15,3 +15,5 @@ cmake \
 make -j ${CPU_COUNT}
 
 make install-libtiledbsoma
+
+cd .. && rm -rf libtiledbsoma-build

--- a/recipe/build-tiledbsoma-py.sh
+++ b/recipe/build-tiledbsoma-py.sh
@@ -6,3 +6,5 @@ cd apis/python
 
 echo "$PKG_VERSION" >> RELEASE-VERSION
 $PYTHON setup.py install --single-version-externally-managed --record record.txt --libtiledbsoma="${PREFIX}"
+
+$PYTHON setup.py clean --all


### PR DESCRIPTION
This ensures in a multi-package build scenario each source build starts with a clean directory.

This is a further of the initial work that cleaned up the R package after each build.

Note: I didn't bump the build number because this won't cause any artifact changes and we don't need to re-upload.