### PR TITLE
Always update conda-smithy for nightly job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,8 +33,10 @@ jobs:
           create-args: conda-smithy
           cache-environment: true
       - name: Rerender feedstock
-        shell: bash -l {0}
-        run: conda smithy rerender --commit auto
+        shell: bash -el {0}
+        run: |
+          micromamba update --yes conda-smithy
+          conda smithy rerender --commit auto
       - name: Push update to GitHub
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/tiledbsoma-feedstock' && github.event_name != 'pull_request' }}
         run: git push --force origin HEAD:nightly-build


### PR DESCRIPTION
conda-smithy checks if it is the latest version available, and since the job caches the conda env, it fails to rerender the feedstock every time there is a new conda-smithy release