### PR TITLE
Canary to check for `numba>=0.58`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,22 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
-!/*/
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,7 +104,7 @@ outputs:
         - anndata <0.9  # [py<=37]
         - tiledb-py >=0.24.0,<0.25.0
         - typing-extensions >=4.1
-        - numba >=0.58.0
+        - numba >=0.58.1
         - attrs >=22.2
         - somacore >=1.0.6
         - scanpy 1.9.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,7 +104,7 @@ outputs:
         - anndata <0.9  # [py<=37]
         - tiledb-py >=0.24.0,<0.25.0
         - typing-extensions >=4.1
-        - numba
+        - numba >=0.58.0
         - attrs >=22.2
         - somacore >=1.0.6
         - scanpy 1.9.*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -104,7 +104,8 @@ outputs:
         - anndata <0.9  # [py<=37]
         - tiledb-py >=0.24.0,<0.25.0
         - typing-extensions >=4.1
-        - numba >=0.58.1
+        - numba >=0.58.1 # [py>37]
+        - numba          # [py<=37]
         - attrs >=22.2
         - somacore >=1.0.6
         - scanpy 1.9.*


### PR DESCRIPTION
https://github.com/single-cell-data/TileDB-SOMA/pull/1723 made me nervous so I want to run a condability check

This is neither a release tag nor immediate prep for a release tag. But let's make this change before TileDB-SOMA 1.7.0.

Note numba 0.58.* isn't available for Python 3.7 and never will be as Anaconda has dropped support for Python 3.7.