### PR TITLE
tiledbsoma 1.5.0rc3 pre-tag check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.5.0rc2" %}
+{% set version = "1.5.0rc3" %}
 {% set sha256 = "ca0a09b4981f2c68f820ca4baf679f974b0b92d1a5c016a3a2d12d2795b67144" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
@@ -12,16 +12,16 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-release canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 4e3a5181eb753004ef0491b18a8b8f30494cfc3a
-#  git_depth: -1
-#  # hoping to be 1.5.0rc2 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: 9f481a22101bd6fb6466656554634ef478a50157
+  git_depth: -1
+  # hoping to be 1.5.0rc3 <-- FILL IN HERE
 
 
 build:


### PR DESCRIPTION
I am starting this rolling in case of any delay with 1.5.0 -- if 1.5.0 comes out soon I'll cancel this

Established procedure:
https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases