### PR TITLE
tiledbsoma 1.5.0 pre-check redux

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -35,6 +35,7 @@ python:
 - 3.9.* *_cpython
 r_base:
 - '4.2'
+- '4.3'
 spdlog:
 - '1.11'
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,7 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge,tiledb
 channel_targets:
@@ -13,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fmt:
 - '9'
 macos_machine:
@@ -35,6 +35,7 @@ python:
 - 3.9.* *_cpython
 r_base:
 - '4.2'
+- '4.3'
 spdlog:
 - '1.11'
 target_platform:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,7 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '15'
+- '16'
 channel_sources:
 - conda-forge,tiledb
 channel_targets:
@@ -11,7 +11,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '15'
+- '16'
 fmt:
 - '9'
 macos_machine:
@@ -33,6 +33,7 @@ python:
 - 3.9.* *_cpython
 r_base:
 - '4.2'
+- '4.3'
 spdlog:
 - '1.11'
 target_platform:

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,7 +34,7 @@ CONDARC
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,7 +26,7 @@ conda activate base
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
     pip mamba conda-build boa conda-forge-ci-setup=3
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,11 +41,11 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.17.1,<2.18
+        - tiledb >=2.17.4,<2.18
         - spdlog
         - fmt
       run:
-        - tiledb >=2.17.1,<2.18
+        - tiledb >=2.17.4,<2.18
         - spdlog
         - fmt
     about:
@@ -96,7 +96,7 @@ outputs:
         - scipy
         - anndata <0.10 # [py>37]
         - anndata <0.9  # [py<=37]
-        - tiledb-py >=0.23.1,<0.24.0
+        - tiledb-py >=0.23.4,<0.24.0
         - typing-extensions >=4.1
         - numba
         - attrs >=22.2
@@ -133,7 +133,7 @@ outputs:
         - r-matrix                   # [build_platform != target_platform]
         - r-bit64                    # [build_platform != target_platform]
         - r-rcppint64                # [build_platform != target_platform]
-        - r-tiledb >=0.21.1,<0.22    # [build_platform != target_platform]
+        - r-tiledb >=0.21.3,<0.22    # [build_platform != target_platform]
         - r-arrow                    # [build_platform != target_platform]
         - r-fs                       # [build_platform != target_platform]
         - r-glue                     # [build_platform != target_platform]
@@ -149,7 +149,7 @@ outputs:
         - r-matrix
         - r-bit64
         - r-rcppint64
-        - r-tiledb >=0.21.1,<0.22
+        - r-tiledb >=0.21.3,<0.22
         - r-arrow
         - r-fs
         - r-glue
@@ -165,7 +165,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64
-        - r-tiledb >=0.21.1,<0.22
+        - r-tiledb >=0.21.3,<0.22
         - r-arrow
         - r-fs
         - r-glue


### PR DESCRIPTION
Follow-on to #55 after `TileDB-SOMA` PRs since then.

See also https://github.com/single-cell-data/TileDB-SOMA/issues/1862

Standard release procedure: https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases