### PR TITLE
tiledbsoma 1.6.0 pre-release check 1

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -74,7 +74,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build conda-forge-ci-setup=4
+    pip mamba conda-build boa conda-forge-ci-setup=4
 
 
 
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,6 +73,7 @@ outputs:
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
         - pyarrow                                # [build_platform != target_platform]
+        - pyarrow_hotfix                         # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
       host:
         - python
@@ -89,6 +90,7 @@ outputs:
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
         - pyarrow <13.0 # [osx]
         - pyarrow       # [not osx]
+        - pyarrow_hotfix
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
@@ -96,6 +98,7 @@ outputs:
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
         - pyarrow <13.0 # [osx]
         - pyarrow       # [not osx]
+        - pyarrow_hotfix
         - python
         - scipy
         - anndata <0.10 # [py>37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.5.1" %}
-{% set sha256 = "c3ab7b0ebeec8c9acf99a29a33c269f22db19e5dab6bcf508b2e615f206231e9" %}
+{% set version = "1.6.0" %}
+{% set sha256 = "tee-bee-dee" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -12,16 +12,16 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-release canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 41754de2d65960b12378947b8cfe108cd0e6baaa
-#  git_depth: -1
-#  # hoping to be 1.5.1 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: 8616aa0b0848e356efd343e4cfd28df5e8b94a3f
+  git_depth: -1
+  # hoping to be 1.6.0 <-- FILL IN HERE
 
 
 build:
@@ -41,11 +41,11 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.17.4,<2.18
+        - tiledb >=2.18.2,<2.19
         - spdlog
         - fmt
       run:
-        - tiledb >=2.17.4,<2.18
+        - tiledb >=2.18.2,<2.19
         - spdlog
         - fmt
     about:
@@ -86,17 +86,21 @@ outputs:
         - setuptools_scm
         - wheel
         - numpy
-        - pyarrow
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
+        - pyarrow <13.0 # [osx]
+        - pyarrow       # [not osx]
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - pandas
-        - pyarrow
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
+        - pyarrow <13.0 # [osx]
+        - pyarrow       # [not osx]
         - python
         - scipy
         - anndata <0.10 # [py>37]
         - anndata <0.9  # [py<=37]
-        - tiledb-py >=0.23.4,<0.24.0
+        - tiledb-py >=0.24.0,<0.25.0
         - typing-extensions >=4.1
         - numba
         - attrs >=22.2
@@ -133,7 +137,7 @@ outputs:
         - r-matrix                   # [build_platform != target_platform]
         - r-bit64                    # [build_platform != target_platform]
         - r-rcppint64                # [build_platform != target_platform]
-        - r-tiledb >=0.21.3,<0.22    # [build_platform != target_platform]
+        - r-tiledb >=0.22.0,<0.23    # [build_platform != target_platform]
         - r-arrow                    # [build_platform != target_platform]
         - r-fs                       # [build_platform != target_platform]
         - r-glue                     # [build_platform != target_platform]
@@ -149,7 +153,7 @@ outputs:
         - r-matrix
         - r-bit64
         - r-rcppint64
-        - r-tiledb >=0.21.3,<0.22
+        - r-tiledb >=0.22.0,<0.23
         - r-arrow
         - r-fs
         - r-glue
@@ -165,7 +169,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64
-        - r-tiledb >=0.21.3,<0.22
+        - r-tiledb >=0.22.0,<0.23
         - r-arrow
         - r-fs
         - r-glue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,7 +72,9 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
-        - pyarrow                                # [build_platform != target_platform]
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
+        - pyarrow <13.0                          # [build_platform != target_platform and osx]
+        - pyarrow                                # [build_platform != target_platform and not osx]
         - pyarrow-hotfix                         # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
       host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -73,7 +73,7 @@ outputs:
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
         - pyarrow                                # [build_platform != target_platform]
-        - pyarrow_hotfix                         # [build_platform != target_platform]
+        - pyarrow-hotfix                         # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
       host:
         - python
@@ -90,7 +90,7 @@ outputs:
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
         - pyarrow <13.0 # [osx]
         - pyarrow       # [not osx]
-        - pyarrow_hotfix
+        - pyarrow-hotfix
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
@@ -98,7 +98,7 @@ outputs:
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1926
         - pyarrow <13.0 # [osx]
         - pyarrow       # [not osx]
-        - pyarrow_hotfix
+        - pyarrow-hotfix
         - python
         - scipy
         - anndata <0.10 # [py>37]


### PR DESCRIPTION
As usual: https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases

except: https://github.com/single-cell-data/TileDB-SOMA/issues/1926#issuecomment-1834695149

-- here we need to validate:

* core 2.18
* `tiledb-py` 0.24
* `tiledb-r` 0.22
* `pyarrow` as noted in the linked issue above

There will be a `somacore` bump later, and another `tiledbsoma` PR, before 1.6.0 -- so there will be a second Conda pre-release-check PR, following on this one