### PR TITLE
tiledbsoma 1.5.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
-*.pyc
+# User content belongs under recipe/.
+# Feedstock configuration goes in `conda-forge.yml`
+# Everything else is managed by the conda-smithy rerender process.
+# Please do not modify
 
-build_artifacts
+*
+!/conda-forge.yml
+
+!/*/
+!/recipe/**
+!/.ci_support/**
+
+*.pyc

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.5.2" %}
-{% set sha256 = "bf9aa81b6e7ffc6a4b1b7a8f3a97698898d837e3449b8906d636c105011ed766" %}
+{% set version = "1.5.3" %}
+{% set sha256 = "13506337c4738a7f1e1cc9a5296af01ab558d677ddff7554648cd7632b0069a9" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -19,9 +19,9 @@ source:
 # Pre-release canary "will Conda be green if we release":
 #source:
 #  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: e444529ce86071c04143a96ad8d5777a1a002a58
+#  git_rev: 239e7304c9ec1357c0cc532df19db9f00cd9f7b1
 #  git_depth: -1
-#  # hoping to be 1.5.2 <-- FILL IN HERE
+#  # hoping to be 1.5.3 <-- FILL IN HERE
 
 
 build:


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

See also #70 for a previous PR on this branch (for 1.5.2). See #72 for the pre-check PR.