### PR TITLE
tiledbsoma 1.7.0 pre-check #3

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,10 +17,10 @@ docker_image:
 fmt:
 - '9'
 numpy:
+- '1.22'
 - '1.21'
-- '1.20'
-- '1.20'
-- '1.20'
+- '1.22'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -19,9 +19,9 @@ fmt:
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
-- '1.21'
-- '1.20'
-- '1.20'
+- '1.22'
+- '1.22'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -17,9 +17,9 @@ fmt:
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
-- '1.21'
-- '1.20'
-- '1.20'
+- '1.22'
+- '1.22'
+- '1.22'
 pin_run_as_build:
   python:
     min_pin: x.x

--- a/.gitignore
+++ b/.gitignore
@@ -3,11 +3,22 @@
 # Everything else is managed by the conda-smithy rerender process.
 # Please do not modify
 
+# Ignore all files and folders in root
 *
 !/conda-forge.yml
 
-!/*/
+# Don't ignore any files/folders if the parent folder is 'un-ignored'
+# This also avoids warnings when adding an already-checked file with an ignored parent.
+!/**/
+# Don't ignore any files/folders recursively in the following folders
 !/recipe/**
 !/.ci_support/**
+
+# Since we ignore files/folders recursively, any folders inside
+# build_artifacts gets ignored which trips some build systems.
+# To avoid that we 'un-ignore' all files/folders recursively
+# and only ignore the root build_artifacts folder.
+!/build_artifacts/**
+/build_artifacts
 
 *.pyc

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -57,12 +57,6 @@ if [[ -f "${FEEDSTOCK_ROOT}/LICENSE.txt" ]]; then
   cp "${FEEDSTOCK_ROOT}/LICENSE.txt" "${RECIPE_ROOT}/recipe-scripts-license.txt"
 fi
 
-if [[ "${sha:-}" == "" ]]; then
-  pushd ${FEEDSTOCK_ROOT}
-  sha=$(git rev-parse HEAD)
-  popd
-fi
-
 if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     if [[ "x${BUILD_OUTPUT_ID:-}" != "x" ]]; then
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --output-id ${BUILD_OUTPUT_ID}"

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -21,6 +21,12 @@ if [ -z ${FEEDSTOCK_NAME} ]; then
     export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
 fi
 
+if [[ "${sha:-}" == "" ]]; then
+  pushd "${FEEDSTOCK_ROOT}"
+  sha=$(git rev-parse HEAD)
+  popd
+fi
+
 docker info
 
 # In order for the conda-build process in the container to write to the mounted

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -9,10 +9,10 @@ channel_targets:
 channel_priority:
   - strict
 numpy:
-  - 1.20   # [not osx]
-  - 1.20
-  - 1.20
-  - 1.21
+  - 1.21   # [not osx]
+  - 1.22
+  - 1.22
+  - 1.22
 python:
   - 3.7.* *_cpython   # [not osx]
   - 3.8.* *_cpython

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -110,7 +110,7 @@ outputs:
         - numba >=0.58.1 # [py>37]
         - numba          # [py<=37]
         - attrs >=22.2
-        - somacore >=1.0.6
+        - somacore >=1.0.7
         - scanpy 1.9.*
     test:
       imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.6.2" %}
-{% set sha256 = "d9033f801c2d7f1cc9cf32e9d02ee8eaca88fe06b64b8073a3175f1f8d8f7c8d" %}
+{% set version = "1.7.0" %}
+{% set sha256 = "tee-bee-dee" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -13,16 +13,16 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 94bbc6f3043f8683595d6f89afef6afb3743c12f
-#  git_depth: -1
-#  # hoping to be 1.6.2 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: 8d858e656d67455525fa1933d43aa148854e998e
+  git_depth: -1
+  # hoping to be 1.7.0 <-- FILL IN HERE
 
 
 build:
@@ -42,7 +42,10 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb =2.18.2
+        # Please see
+        # https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/76#discussion_r1457880263
+        # before changing this:
+        - tiledb >=2.19.1,<2.20
         - spdlog
         - fmt
     about:
@@ -102,9 +105,10 @@ outputs:
         - scipy
         - anndata <0.10 # [py>37]
         - anndata <0.9  # [py<=37]
-        - tiledb-py >=0.24.0,<0.25.0
+        - tiledb-py >=0.25.0,<0.26.0
         - typing-extensions >=4.1
-        - numba
+        - numba >=0.58.1 # [py>37]
+        - numba          # [py<=37]
         - attrs >=22.2
         - somacore >=1.0.6
         - scanpy 1.9.*
@@ -139,7 +143,7 @@ outputs:
         - r-matrix                   # [build_platform != target_platform]
         - r-bit64                    # [build_platform != target_platform]
         - r-rcppint64                # [build_platform != target_platform]
-        - r-tiledb >=0.22.0,<0.23    # [build_platform != target_platform]
+        - r-tiledb >=0.23.0,<0.24    # [build_platform != target_platform]
         - r-arrow                    # [build_platform != target_platform]
         - r-fs                       # [build_platform != target_platform]
         - r-glue                     # [build_platform != target_platform]
@@ -155,7 +159,7 @@ outputs:
         - r-matrix
         - r-bit64
         - r-rcppint64
-        - r-tiledb >=0.22.0,<0.23
+        - r-tiledb >=0.23.0,<0.24
         - r-arrow
         - r-fs
         - r-glue
@@ -171,7 +175,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64
-        - r-tiledb >=0.22.0,<0.23
+        - r-tiledb >=0.23.0,<0.24
         - r-arrow
         - r-fs
         - r-glue


### PR DESCRIPTION
One more check in the vein of #78 before tagging TileDB-SOMA 1.7.0 in GitHub, following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases).