### PR TITLE
tiledbsoma 1.7.1 pre-check

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '9'
+- '10'
 numpy:
 - '1.22'
 - '1.21'
@@ -37,7 +37,7 @@ r_base:
 - '4.2'
 - '4.3'
 spdlog:
-- '1.11'
+- '1.12'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 fmt:
-- '9'
+- '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -37,7 +37,7 @@ r_base:
 - '4.2'
 - '4.3'
 spdlog:
-- '1.11'
+- '1.12'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -13,7 +13,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 fmt:
-- '9'
+- '10'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -35,7 +35,7 @@ r_base:
 - '4.2'
 - '4.3'
 spdlog:
-- '1.11'
+- '1.12'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.7.0" %}
-{% set sha256 = "7c712d03bbc511936816130f4e2af1ee6f467f2426c69f118042975a2175fdf0" %}
+{% set version = "1.7.1" %}
+{% set sha256 = "TBD" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -13,16 +13,16 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 8d858e656d67455525fa1933d43aa148854e998e
-#  git_depth: -1
-#  # hoping to be 1.7.0 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: c7eb1c1bc630689139bcc0a915465aae23405f04
+  git_depth: -1
+  # hoping to be 1.7.1 <-- FILL IN HERE
 
 
 build:


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)