### PR TITLE
Rerender, and fix `libgoogle-cloud` issues

### DIFF
--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -34,9 +34,9 @@ CONDARC
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"
@@ -68,7 +68,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda mambabuild "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/.scripts/run_osx_build.sh
+++ b/.scripts/run_osx_build.sh
@@ -26,9 +26,9 @@ export CONDA_SOLVER="libmamba"
 export CONDA_LIBMAMBA_SOLVER_NO_CHANNELS_FROM_INSTALLED=1
 
 mamba install --update-specs --quiet --yes --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
-    pip mamba conda-build boa conda-forge-ci-setup=4
+    pip mamba conda-build conda-forge-ci-setup=4 "conda-build>=24.1"
 
 
 
@@ -81,7 +81,7 @@ else
         EXTRA_CB_OPTIONS="${EXTRA_CB_OPTIONS:-} --no-test"
     fi
 
-    conda mambabuild ./recipe -m ./.ci_support/${CONFIG}.yaml \
+    conda build ./recipe -m ./.ci_support/${CONFIG}.yaml \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file ./.ci_support/clobber_${CONFIG}.yaml \
         --extra-meta flow_run_id="$flow_run_id" remote_url="$remote_url" sha="$sha"

--- a/build-locally.py
+++ b/build-locally.py
@@ -64,8 +64,9 @@ def verify_config(ns):
     elif ns.config.startswith("osx"):
         if "OSX_SDK_DIR" not in os.environ:
             raise RuntimeError(
-                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=SDKs' "
-                "to download the SDK automatically to 'SDKs/MacOSX<ver>.sdk'. "
+                "Need OSX_SDK_DIR env variable set. Run 'export OSX_SDK_DIR=$PWD/SDKs' "
+                "to download the SDK automatically to '$PWD/SDKs/MacOSX<ver>.sdk'. "
+                "Note: OSX_SDK_DIR must be set to an absolute path. "
                 "Setting this variable implies agreement to the licensing terms of the SDK by Apple."
             )
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,6 +45,7 @@ outputs:
         - tiledb >=2.19.1,<2.20
         - spdlog
         - fmt
+        - libgoogle-cloud 2.12.*
     about:
       home: http://tiledb.com
       license: MIT
@@ -90,6 +91,7 @@ outputs:
         - pyarrow <13.0 # [osx]
         - pyarrow       # [not osx]
         - pyarrow-hotfix
+        - libgoogle-cloud 2.12.*
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -100,7 +100,7 @@ outputs:
         - pyarrow-hotfix
         - python
         - scipy
-        - anndata <0.10 # [py>37]
+        - anndata       # [py>37]
         - anndata <0.9  # [py<=37]
         - tiledb-py >=0.25.0,<0.26.0
         - typing-extensions >=4.1
@@ -108,7 +108,7 @@ outputs:
         - numba          # [py<=37]
         - attrs >=22.2
         - somacore >=1.0.7
-        - scanpy 1.9.*
+        - scanpy >=1.9.2
     test:
       imports:
         - tiledbsoma


### PR DESCRIPTION
This is on `main` with tiledbsoma 1.7.2. See also #91 which attempts a pre-check for 1.8.0.

This doesn't bump any application-level versions -- hence build number 1. This works around problems that have recently arisen in our dependencies, problems which made a previously solvable recipe no longer solvable.

Solver issue:

```
744:    Encountered problems while solving:
745-      - package tiledb-2.19.1-hc0b898c_0 requires libcurl >=7.87.0,<8.0a0, but none of the providers can be installed
746-
747-    Could not solve for environment specs
748-    The following packages are incompatible
749-    ├─ libgoogle-cloud-storage 2.21.*  is installable and it requires
750-    │  └─ libgoogle-cloud [2.21.0 h31df0ca_0|2.21.0 h31df0ca_1|2.21.0 h72bcb37_2], which requires
751-    │     └─ libcurl >=8.5.0,<9.0a0 , which can be installed;
752-    └─ tiledb >=2.19.1,<2.20  is not installable because there are no viable options
753-       ├─ tiledb 2.19.1 would require
754-       │  └─ libgoogle-cloud >=2.12.0,<2.13.0a0 , which conflicts with any installable versions previously reported;
755-       ├─ tiledb 2.19.1 would require
756-       │  └─ libcurl >=7.88.1,<8.0a0 , which conflicts with any installable versions previously reported;
757-       └─ tiledb 2.19.1 would require
758-          └─ libcurl >=7.87.0,<8.0a0 , which conflicts with any installable versions previously reported.
```

```
tiledb 2.19.1 requires libgoogle-cloud 2.12.*
```

Supporting info:

* `google-cloud-cpp`
  * https://anaconda.org/conda-forge/google-cloud-cpp/files
  * Has 2.11 2.12 2.21
* `libgoogle-cloud`
  * https://anaconda.org/conda-forge/libgoogle-cloud
  * Has 2.11 2.12 2.17 2.21
* `libgoogle-cloud-storage`
  * https://anaconda.org/conda-forge/libgoogle-cloud-storage
  * Has 2.17 2.21

See also:

<details>

https://anaconda.org/conda-forge/tiledb/files?version=2.19.1
```
Type  Size  Name
conda 5.8MB linux-64/tiledb-2.19.1-h4386cac_0.conda
conda 5.8MB linux-64/tiledb-2.19.1-h584b59b_0.conda
conda 5.8MB linux-64/tiledb-2.19.1-hc0b898c_0.conda
```

https://anaconda.org/conda-forge/tiledb/2.19.1/download/linux-64/tiledb-2.19.1-h4386cac_0.conda

```
wget https://anaconda.org/conda-forge/tiledb/2.19.1/download/linux-64/tiledb-2.19.1-h4386cac_0.conda
```

```
ubuntu@anzo[prod][][~]$ conda inspect hash-inputs tiledb-2.19.1-h4386cac_0.conda
{'tiledb-2.19.1-h4386cac_0.conda': {'recipe': {'bzip2': '1',
                                               'channel_targets': 'conda-forge '
                                                                  'main',
                                               'cxx_compiler': 'gxx',
                                               'cxx_compiler_version': '12',
                                               'gcs': 'gcs_enabled',
                                               'google_cloud_cpp': '2.12',
                                               'libabseil': '20230802',
                                               'libcurl': '8',
                                               'libxml2': '2',
                                               'lz4_c': '1.9.3',
                                               'openssl': '3',
                                               'target_platform': 'linux-64',
                                               'zlib': '1.2',
                                               'zstd': '1.5'}}}
```

https://anaconda.org/tiledb/tiledb/files?channel=for-cloud&version=2.19.1

```
wget https://anaconda.org/tiledb/tiledb/2.19.1/download/linux-64/tiledb-2.19.1-h24029db_1.conda
```

```
conda inspect hash-inputs tiledb-2.19.1-h24029db_1.conda
{'tiledb-2.19.1-h24029db': {'recipe': {'channel_targets': 'tiledb for-cloud',
                                       'cxx_compiler': 'gxx',
                                       'cxx_compiler_version': '12',
                                       'target_platform': 'linux-64'}}}
```

https://github.com/conda-forge/tiledb-feedstock/blob/295eacda3ca366b2795b526c5de233931e5aa2a2/recipe/meta.yaml

</details>
