### PR TITLE
Use `somacore == 1.0.7` for `tiledbsoma` 1.7.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,7 +26,7 @@ source:
 
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 
@@ -109,7 +109,7 @@ outputs:
         - numba >=0.58.1 # [py>37]
         - numba          # [py<=37]
         - attrs >=22.2
-        - somacore >=1.0.7
+        - somacore ==1.0.7
         - scanpy >=1.9.2
     test:
       imports:


### PR DESCRIPTION
We have some cloud CI failing because:

* `tiledbsoma-feedstock` has `somacore >= 1.0.7` https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/6663e5111ccd0a74dd5e4f01781918f4bf52879d/recipe/meta.yaml#L112
* https://github.com/single-cell-data/TileDB-SOMA/pull/2001 is a PR that needs `somacore` 1.0.8` -- there are fails without that PR and with 1.0.8, and fails with that PR and without 1.0.8
* The aforementioned cloud PR is just a patch on top of existing `tiledbsoma` 1.7
* So I need to update `tiledbsoma-feedstock` to pin to `somacore == 1.0.7` -- this PR