### PR TITLE
Make `somacore` dependency exact to match `tiledbsoma`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,10 @@
 # from
 #   https://github.com/single-cell-data/TileDB-SOMA/releases/tag/i.j.k
 #
-# See also build number below
+# See also build number below.
+#
+# Also double-check somacore version against TileDB-SOMA's setup.py: this bumps very infrequently
+# but it can.
 
 package:
   name: {{ name }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,7 @@ source:
 
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -112,7 +112,8 @@ outputs:
         - numba >=0.58.1 # [py>37]
         - numba          # [py<=37]
         - attrs >=22.2
-        - somacore >=1.0.8
+        # Keep this in sync with TileDB-SOMA's somacore version requirement.
+        - somacore ==1.0.8
         - scanpy >=1.9.2
         # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]


### PR DESCRIPTION
A previous version of tiledb-soma erroneously marked itself as compatible with versions of tilebsoma v1.0.8. This is because the PyPI package (https://github.com/single-cell-data/TileDB-SOMA/blob/1.8.0/apis/python/setup.py#L332) lists itself as only compatible with == a version, but this Conda package listed itself as compatible with >= a version.