### PR TITLE
[ci skip] Open Issue if nightly Azure build fails

### DIFF
--- a/.github/scripts/nightly/check-azure-status.sh
+++ b/.github/scripts/nightly/check-azure-status.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+# Check status of Azure build. Open Issue if failed
+#
+# https://learn.microsoft.com/en-us/rest/api/azure/devops/build/status/get
+#
+# Usage: bash check-azure-status.sh <azure-build-id> <azure-build-name>
+#        bash check-azure-status.sh 4 tiledbfeedstock_CI
+#
+# Requires env var GH_TOKEN with a GitHub token with write-access to Issues
+
+AZURE_ORG="TileDB-Inc"
+AZURE_PROJECT="CI"
+AZURE_BUILD_ID="$1"
+AZURE_BUILD_NAME="$2"
+AZURE_BUILD_BRANCH="nightly-build"
+
+echo "Checking status of branch $AZURE_BUILD_BRANCH" \
+     "for build $AZURE_BUILD_NAME (id: $AZURE_BUILD_ID) in $AZURE_ORG/$AZURE_PROJECT"
+
+ENDPOINT="https://dev.azure.com/$AZURE_ORG/$AZURE_PROJECT/_apis/build/status/$AZURE_BUILD_NAME?branchName=$AZURE_BUILD_BRANCH"
+
+if curl -sL $ENDPOINT | grep -q succeeded
+then
+  echo "Build succeeded"
+  exit 0
+fi
+
+echo "Build failed"
+curl -sL $ENDPOINT | tail -n 3
+
+# Open Issue or comment on existing one
+
+theMessage="Nightly feedstock build failure for $AZURE_BUILD_NAME at https://dev.azure.com/$AZURE_ORG/$AZURE_PROJECT/_build?definitionId=$AZURE_BUILD_ID&_a=summary"
+echo $theMessage
+
+if [[ -z "$GH_TOKEN" ]]
+then
+  echo "The env var GH_TOKEN is missing"
+  echo "Please define it as a GitHub PAT with write permissions to Issues"
+  exit 1
+fi
+
+existing=$(gh issue list \
+  --label nightly-failure \
+  --limit 1 \
+  --jq '.[].number' \
+  --json "number" \
+  --state "open")
+
+if [[ -z "$existing" ]]
+then
+  echo "Opening new issue"
+  gh issue create \
+    --assignee "johnkerl,jdblischak" \
+    --body "$theMessage" \
+    --label "nightly-failure" \
+    --title "Nighly feedstock build failed"
+else
+  echo "Commenting on existing issue"
+  gh issue comment "$existing" \
+    --body "$theMessage"
+fi

--- a/.github/workflows/nightly-azure-status.yml
+++ b/.github/workflows/nightly-azure-status.yml
@@ -1,0 +1,39 @@
+# Need to query the Azure Status API endpoint to determine if nightly
+# feedstock builds passed or failed
+# https://learn.microsoft.com/en-us/rest/api/azure/devops/build/status/get
+name: nightly-azure-status
+on:
+  schedule:
+     # https://crontab.guru/#0_11_*_*_*
+     - cron: "0 11 * * *" # Every day at 11 AM UTC (6 AM EST; 7 AM EDT)
+  workflow_dispatch:
+jobs:
+  nightly-azure-status:
+    # https://dev.azure.com/TileDB-Inc/CI/_build?definitionId=43&_a=summary&repositoryFilter=39&branchFilter=8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732%2C8732
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Azure Status API
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run:  bash .github/scripts/nightly/check-azure-status.sh 43 tiledbsoma-feedstock
+  # This Issue is opened only if there was a technical problem with this GitHub
+  # workflow. The jobs above open an Issue if they detect a failed Azure build
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: nightly-azure-status
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open Issue
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: azure status check
+          label: nightly-azure-status-failure
+          assignee: johnkerl,jdblischak
+        env:
+          TZ: "America/New_York"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,7 +19,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Update recipe source to use Git repo
         run: bash .github/scripts/nightly/update-recipe.sh
       - name: Update feedstock
@@ -40,3 +40,19 @@ jobs:
       - name: Push update to GitHub
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/tiledbsoma-feedstock' && github.event_name != 'pull_request' }}
         run: git push --force origin HEAD:nightly-build
+  issue:
+    permissions:
+      issues: write
+    runs-on: ubuntu-latest
+    needs: nightly
+    if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Open Issue
+        uses: TileDB-Inc/github-actions/open-issue@main
+        with:
+          name: nightly setup
+          label: nightly-setup-failure
+          assignee: johnkerl,jdblischak
+        env:
+          TZ: "America/New_York"


### PR DESCRIPTION
This PR updates the nightly builds so that they open an Issue if they fail.

I created 3 new [labels](https://github.com/TileDB-Inc/tiledbsoma-feedstock/labels) (which is how my `open-issue` action knows whether to open a new issue or comment on an existing open one)

![image](https://github.com/TileDB-Inc/tiledbsoma-feedstock/assets/1608317/9c5b2231-f43d-47d5-8624-4be6b9eaff6c)

Now an Issue will be opened for any of the following failures:

* The nightly Azure build failed (the most important). These Issues will be labeled `nightly-failure`
* The GitHub Actions workflow to trigger the nightly build failed. These Issues will be labeled `nightly-setup-failure`. These failures are almost always spurious and can usually be fixed with a restart
* The GitHub Actions workflow to check the Azure nightly status failed. These Issues will be labeled `nightly-azure-status-failure`. These errors should be rare

I copy-paste-modified this setup from 

https://github.com/TileDB-Inc/conda-forge-nightly-controller/blob/f78c27c418589b9441b14f63e14889889474f0d6/scripts/check-azure-status.sh
https://github.com/TileDB-Inc/conda-forge-nightly-controller/blob/f78c27c418589b9441b14f63e14889889474f0d6/.github/workflows/check-azure-status.yml
https://github.com/TileDB-Inc/conda-forge-nightly-controller/blob/f78c27c418589b9441b14f63e14889889474f0d6/.github/workflows/tiledb.yml#L60
