### PR TITLE
[ci skip] Pin conda-smithy to 3.31.1

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,12 +30,12 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: env
-          create-args: conda-smithy
+          create-args: conda-smithy=3.31.1
           cache-environment: true
       - name: Rerender feedstock
         shell: bash -el {0}
         run: |
-          micromamba update --yes conda-smithy
+          #micromamba update --yes conda-smithy
           conda smithy rerender --no-check-uptodate --commit auto
       - name: Push update to GitHub
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/tiledbsoma-feedstock' && github.event_name != 'pull_request' }}


### PR DESCRIPTION
Have to pin to 3.31.1 until the Issue with 3.32.0 is resolved. It rejects the Azure project information in `conda-forge.yml`

Bug report filed at https://github.com/conda-forge/conda-smithy/issues/1864

https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/a05739d3e236bb355b2c772c3c5ac0ebdf6ec414/conda-forge.yml#L11-L14

Successful [run](https://github.com/jdblischak/tiledbsoma-feedstock/actions/runs/8300733407) on my fork