### PR TITLE
Build two variants: one for cloud and one for conda-forge

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -8,8 +8,12 @@ jobs:
     vmImage: ubuntu-latest
   strategy:
     matrix:
-      linux_64_:
-        CONFIG: linux_64_
+      linux_64_fmt10spdlog1.12:
+        CONFIG: linux_64_fmt10spdlog1.12
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_64_fmt9spdlog1.11:
+        CONFIG: linux_64_fmt9spdlog1.11
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360

--- a/.ci_support/linux_64_fmt10spdlog1.12.yaml
+++ b/.ci_support/linux_64_fmt10spdlog1.12.yaml
@@ -1,21 +1,21 @@
-MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
 c_compiler:
-- clang
+- gcc
 c_compiler_version:
-- '16'
+- '12'
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,tiledb
 channel_targets:
 - tiledb main
 cxx_compiler:
-- clangxx
+- gxx
 cxx_compiler_version:
-- '16'
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
 - '10'
-macos_machine:
-- arm64-apple-darwin20.0.0
 numpy:
 - '1.22'
 - '1.23'
@@ -39,9 +39,12 @@ r_base:
 spdlog:
 - '1.12'
 target_platform:
-- osx-arm64
+- linux-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - channel_sources
+  - fmt
+  - spdlog
 - - python
   - numpy

--- a/.ci_support/linux_64_fmt9spdlog1.11.yaml
+++ b/.ci_support/linux_64_fmt9spdlog1.11.yaml
@@ -5,7 +5,7 @@ c_compiler_version:
 cdt_name:
 - cos6
 channel_sources:
-- conda-forge,tiledb
+- tiledb/label/for-cloud,conda-forge,tiledb
 channel_targets:
 - tiledb main
 cxx_compiler:
@@ -43,7 +43,8 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - fmt
+- - channel_sources
+  - fmt
   - spdlog
 - - python
   - numpy

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '16'
 fmt:
-- '9'
+- '10'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -39,13 +39,11 @@ r_base:
 - '4.2'
 - '4.3'
 spdlog:
-- '1.11'
+- '1.12'
 target_platform:
 - osx-64
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
-- - fmt
-  - spdlog
 - - python
   - numpy

--- a/README.md
+++ b/README.md
@@ -82,10 +82,17 @@ Current build status
         <table>
           <thead><tr><th>Variant</th><th>Status</th></tr></thead>
           <tbody><tr>
-              <td>linux_64</td>
+              <td>linux_64_fmt10spdlog1.12</td>
               <td>
                 <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_" alt="variant">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt10spdlog1.12" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_64_fmt9spdlog1.11</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=main">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt9spdlog1.11" alt="variant">
                 </a>
               </td>
             </tr><tr>

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,18 +4,24 @@ MACOSX_SDK_VERSION:  # [osx and x86_64]
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "11.0"                # [osx and x86_64]
 channel_sources:
+  - tiledb/label/for-cloud,conda-forge,tiledb  # [linux]
   - conda-forge,tiledb
 channel_targets:
   - tiledb main
 channel_priority:
   - strict
 # conda-forge has migrated to fmt 10 and spdlog 1.12. We need fmt 9 to install
-# into our existing TileDB Cloud conda environments, so we are going to delay
-# the migration of this feedstock.
-fmt:
-  - 9
-spdlog:
-  - 1.11
-zip_keys:
-  - fmt
-  - spdlog
+# into our existing TileDB Cloud conda environments, so we build a special
+# variant of fmt 9 and spdlog 1.11. And because this can no longer solve with
+# conda-forge depedencies, we install the "for-cloud" tiledb binary from
+# tiledb/label/for-cloud
+fmt:                 # [linux]
+  - 9                # [linux]
+  - 10               # [linux]
+spdlog:              # [linux]
+  - 1.11             # [linux]
+  - 1.12             # [linux]
+zip_keys:            # [linux]
+  - channel_sources  # [linux]
+  - fmt              # [linux]
+  - spdlog           # [linux]


### PR DESCRIPTION
Closes #101

Supersedes #103 

This PR fixes the current conda solver errors that are failing the nightlies and blocking new PRs by separating the linux-64 build into two separate variants:

1. conda-forge: builds against tiledb from conda-forge and uses the latest conda-forge pins
2. TileDB Cloud: builds against the statically linked "for-cloud" tiledb binary from the tiledb channel and uses the outdated pins (fmt 9 and spdlog 1.11) required for installing into the cloud conda environments