### PR TITLE
[ci skip] Unpin conda-smithy for nightly builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,12 +30,12 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-name: env
-          create-args: conda-smithy=3.31.1
+          create-args: conda-smithy
           cache-environment: true
       - name: Rerender feedstock
         shell: bash -el {0}
         run: |
-          #micromamba update --yes conda-smithy
+          micromamba update --yes conda-smithy
           conda smithy rerender --no-check-uptodate --commit auto
       - name: Push update to GitHub
         if: ${{ github.ref == 'refs/heads/main' && github.repository == 'TileDB-Inc/tiledbsoma-feedstock' && github.event_name != 'pull_request' }}


### PR DESCRIPTION
Undoes PR #102. The problems with conda-smithy 3.32.0 were fixed in [3.33.0](https://github.com/conda-forge/conda-smithy/releases/tag/v3.33.0)

xref: https://github.com/conda-forge/conda-smithy/issues/1864, https://github.com/conda-forge/conda-smithy/pull/1871

Successful [run](https://github.com/jdblischak/tiledbsoma-feedstock/actions/runs/8442281103/job/23123352317) on my fork