### PR TITLE
Return to strict channel priority

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -12,6 +12,3 @@ azure:
   build_id: 43
   user_or_org: TileDB-Inc
   project_name: CI
-# Temporarily required to install tiledb-py with Python 3.7,
-# which is only being built on the "tiledb" channel
-channel_priority: flexible

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -5,7 +5,7 @@ github:
 build_platform:
   osx_arm64: osx_64
 conda_forge_output_validation: true
-test_on_native_only: true
+test: native_and_emulated
 # build_with_mambabuild: false
 upload_on_branch: main
 azure:


### PR DESCRIPTION
We previously enabled flexible channel priority in order to install the py37 tiledb-py from the tiledb channel. Now that we've dropped Python 3.7, this should no longer be necessary.

No need to bump the build number. Just want to confirm the solver can handle this. Then we can merge, and it will be enforced for future builds.

Lastly I made a minor change to update the [deprecated `test_on_native_only` field](https://conda-forge.org/docs/maintainer/conda_forge_yml/#test-on-native-only).

Rerendering had no effect