### PR TITLE
tiledbsoma-r check #2: `snappy==1.1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -162,7 +162,7 @@ outputs:
         # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
         # Temporary https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/126
-        - r-snappy ==1.1
+        - snappy ==1.1
       host:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -161,6 +161,8 @@ outputs:
         - r-rlang                    # [build_platform != target_platform]
         # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
+        # Temporary https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/126
+        - r-snappy ==1.1
       host:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base
@@ -178,8 +180,6 @@ outputs:
         - r-data.table
         - r-spdl
         - r-rlang
-        # Temporary https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/126
-        - r-snappy ==1.1
       run:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -161,8 +161,6 @@ outputs:
         - r-rlang                    # [build_platform != target_platform]
         # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
-        # Temporary https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/126
-        - snappy ==1.1
       host:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base
@@ -180,6 +178,8 @@ outputs:
         - r-data.table
         - r-spdl
         - r-rlang
+        # Temporary https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/126
+        - snappy ==1.1
       run:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -178,6 +178,8 @@ outputs:
         - r-data.table
         - r-spdl
         - r-rlang
+        # Temporary https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/126
+        - r-snappy ==1.1
       run:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base


### PR DESCRIPTION
Another attempt on #126, besides #127

Our working theory :

* A key dependency of `libarrow`, `snappy`, was recently updated
* This broke `libarrow` and any recipe that depended on it
* Folks are already working to clean up the situation on conda-forge, as evidenced in part by the activity at 
  * https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/699
  * https://github.com/conda-forge/conda-forge-repodata-patches-feedstock/pull/700
  * https://github.com/conda-forge/snappy-feedstock/commits/main/ (2024-04-08 commits)