### PR TITLE
[No Not Merge] 1.9.5 pre-check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,15 +16,15 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+# source:
+#   url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#   sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: f42522217d56879e6fd821e23e11f2e226e5e354
-#  git_depth: -1
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: d42583986ffe1e59fb2047fe4d203829740fbef0
+  git_depth: -1
 #  # hoping to be 1.9.3 <-- FILL IN HERE
 
 build:


### PR DESCRIPTION
Now that the snappy/arrow pinning issue has been resolved, our nightly feedstock builds are passing again (#126), and we can proceed with the next release

This is a [feedstock pre-check PR](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases#branchtag-mechanics). It is building against the latest commit on the branch `release-1.9` (also tagged by `1.9.5rc0`)

https://github.com/single-cell-data/TileDB-SOMA/commits/release-1.9/
https://github.com/single-cell-data/TileDB-SOMA/commits/1.9.5rc0
https://github.com/single-cell-data/TileDB-SOMA/commit/d42583986ffe1e59fb2047fe4d203829740fbef0