### PR TITLE
Health check from release tag [do not merge]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
 #  # hoping to be i.j.k <-- FILL IN HERE
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 


### PR DESCRIPTION
#138 and #139 are probes for a pin update and a new platform, respectively.

They've also got some weird stuff happening that I want to factor away from the probe material per se. Hence #140 and #141.