### PR TITLE
Health check from commit hash [do not merge]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
 {% set version = "1.10.1" %}
-{% set sha256 = "a3bff197b3961c4d19a4196ad5361d66a14b61d71cb8916f326e4d2a8738bf3b" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,16 +16,16 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 74afcca3a5b1517c994e790b539ea6249b6fa74b
-#  git_depth: -1
-#  # hoping to be i.j.k <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: c52724add75efa1aab3dfe52510e1ddea43666d8
+  git_depth: -1
+  # hoping to be i.j.k <-- FILL IN HERE
 
 build:
   number: 0


### PR DESCRIPTION
#138 and #139 are probes for a pin update and a new platform, respectively.

They've also got some weird stuff happening that I want to factor away from the probe material per se. Hence #140 and #141.