### PR TITLE
Test-drive linux+arm64 on `dev` branch [WIP] 

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -39,7 +39,7 @@ jobs:
         export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
-        export UPLOAD_ON_BRANCH="ss/test-linux-arm64"
+        export UPLOAD_ON_BRANCH="dev"
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
           export IS_PR_BUILD="True"
         else

--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,6 +16,10 @@ jobs:
         CONFIG: linux_64_fmt9spdlog1.11
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+      linux_aarch64_:
+        CONFIG: linux_aarch64_
+        UPLOAD_PACKAGES: 'True'
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
   variables: {}
 
@@ -35,7 +39,7 @@ jobs:
         export sha=$(Build.SourceVersion)
         export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
         export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
-        export UPLOAD_ON_BRANCH="main"
+        export UPLOAD_ON_BRANCH="ss/test-linux-arm64"
         if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
           export IS_PR_BUILD="True"
         else

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -27,7 +27,7 @@ jobs:
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
-      export UPLOAD_ON_BRANCH="main"
+      export UPLOAD_ON_BRANCH="ss/test-linux-arm64"
       if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
         export IS_PR_BUILD="True"
       else

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -27,7 +27,7 @@ jobs:
       export OSX_FORCE_SDK_DOWNLOAD="1"
       export GIT_BRANCH=$BUILD_SOURCEBRANCHNAME
       export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
-      export UPLOAD_ON_BRANCH="ss/test-linux-arm64"
+      export UPLOAD_ON_BRANCH="dev"
       if [[ "${BUILD_REASON:-}" == "PullRequest" ]]; then
         export IS_PR_BUILD="True"
       else

--- a/.ci_support/linux_64_fmt10spdlog1.12.yaml
+++ b/.ci_support/linux_64_fmt10spdlog1.12.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - conda-forge,tiledb
 channel_targets:
-- tiledb main
+- tiledb experimental
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_64_fmt9spdlog1.11.yaml
+++ b/.ci_support/linux_64_fmt9spdlog1.11.yaml
@@ -11,7 +11,7 @@ cdt_name:
 channel_sources:
 - tiledb/label/for-cloud,conda-forge,tiledb
 channel_targets:
-- tiledb main
+- tiledb experimental
 cxx_compiler:
 - gxx
 cxx_compiler_version:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -1,0 +1,57 @@
+BUILD:
+- aarch64-conda_cos7-linux-gnu
+c_compiler:
+- gcc
+c_compiler_version:
+- '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.17'
+cdt_arch:
+- aarch64
+cdt_name:
+- cos7
+channel_sources:
+- conda-forge,tiledb
+channel_targets:
+- tiledb experimental
+cxx_compiler:
+- gxx
+cxx_compiler_version:
+- '12'
+docker_image:
+- quay.io/condaforge/linux-anvil-cos7-x86_64
+fmt:
+- '10'
+numpy:
+- '1.22'
+- '1.23'
+- '1.22'
+- '1.22'
+pin_run_as_build:
+  python:
+    min_pin: x.x
+    max_pin: x.x
+  r-base:
+    min_pin: x.x
+    max_pin: x.x
+python:
+- 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.8.* *_cpython
+- 3.9.* *_cpython
+r_base:
+- '4.2'
+- '4.3'
+spdlog:
+- '1.12'
+target_platform:
+- linux-aarch64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
+- - python
+  - numpy

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -13,7 +13,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge,tiledb
 channel_targets:
-- tiledb main
+- tiledb experimental
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -11,7 +11,7 @@ c_stdlib_version:
 channel_sources:
 - conda-forge,tiledb
 channel_targets:
-- tiledb main
+- tiledb experimental
 cxx_compiler:
 - clangxx
 cxx_compiler_version:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About tiledbsoma-feedstock
 ==========================
 
-Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/ss/test-linux-arm64/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/dev/LICENSE.txt)
 
 
 About tiledbsoma
@@ -75,8 +75,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
-            <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64">
+          <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=dev">
+            <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=dev">
           </a>
         </summary>
         <table>
@@ -84,36 +84,36 @@ Current build status
           <tbody><tr>
               <td>linux_64_fmt10spdlog1.12</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=linux&configuration=linux%20linux_64_fmt10spdlog1.12" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=dev">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=dev&jobName=linux&configuration=linux%20linux_64_fmt10spdlog1.12" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_fmt9spdlog1.11</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=linux&configuration=linux%20linux_64_fmt9spdlog1.11" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=dev">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=dev&jobName=linux&configuration=linux%20linux_64_fmt9spdlog1.11" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_aarch64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=dev">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=dev&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=dev">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=dev&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=dev">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=dev&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 About tiledbsoma-feedstock
 ==========================
 
-Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/main/LICENSE.txt)
+Feedstock license: [BSD-3-Clause](https://github.com/TileDB-Inc/tiledbsoma-feedstock/blob/ss/test-linux-arm64/LICENSE.txt)
 
 
 About tiledbsoma
@@ -75,8 +75,8 @@ Current build status
     <td>
       <details>
         <summary>
-          <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=main">
-            <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main">
+          <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
+            <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64">
           </a>
         </summary>
         <table>
@@ -84,29 +84,36 @@ Current build status
           <tbody><tr>
               <td>linux_64_fmt10spdlog1.12</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt10spdlog1.12" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=linux&configuration=linux%20linux_64_fmt10spdlog1.12" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>linux_64_fmt9spdlog1.11</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main&jobName=linux&configuration=linux%20linux_64_fmt9spdlog1.11" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=linux&configuration=linux%20linux_64_fmt9spdlog1.11" alt="variant">
+                </a>
+              </td>
+            </tr><tr>
+              <td>linux_aarch64</td>
+              <td>
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=linux&configuration=linux%20linux_aarch64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=osx&configuration=osx%20osx_64_" alt="variant">
                 </a>
               </td>
             </tr><tr>
               <td>osx_arm64</td>
               <td>
-                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=main">
-                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=main&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
+                <a href="https://dev.azure.com/TileDB-Inc/CI/_build/latest?definitionId=43&branchName=ss/test-linux-arm64">
+                  <img src="https://dev.azure.com/TileDB-Inc/CI/_apis/build/status/tiledbsoma-feedstock?branchName=ss/test-linux-arm64&jobName=osx&configuration=osx%20osx_arm64_" alt="variant">
                 </a>
               </td>
             </tr>
@@ -129,14 +136,14 @@ Current release info
 Installing tiledbsoma
 =====================
 
-Installing `tiledbsoma` from the `tiledb` channel can be achieved by adding `tiledb` to your channels with:
+Installing `tiledbsoma` from the `tiledb/label/experimental` channel can be achieved by adding `tiledb/label/experimental` to your channels with:
 
 ```
-conda config --add channels tiledb
+conda config --add channels tiledb/label/experimental
 conda config --set channel_priority strict
 ```
 
-Once the `tiledb` channel has been enabled, `libtiledbsoma, r-tiledbsoma, tiledbsoma-py` can be installed with `conda`:
+Once the `tiledb/label/experimental` channel has been enabled, `libtiledbsoma, r-tiledbsoma, tiledbsoma-py` can be installed with `conda`:
 
 ```
 conda install libtiledbsoma r-tiledbsoma tiledbsoma-py
@@ -151,26 +158,26 @@ mamba install libtiledbsoma r-tiledbsoma tiledbsoma-py
 It is possible to list all of the versions of `libtiledbsoma` available on your platform with `conda`:
 
 ```
-conda search libtiledbsoma --channel tiledb
+conda search libtiledbsoma --channel tiledb/label/experimental
 ```
 
 or with `mamba`:
 
 ```
-mamba search libtiledbsoma --channel tiledb
+mamba search libtiledbsoma --channel tiledb/label/experimental
 ```
 
 Alternatively, `mamba repoquery` may provide more information:
 
 ```
 # Search all versions available on your platform:
-mamba repoquery search libtiledbsoma --channel tiledb
+mamba repoquery search libtiledbsoma --channel tiledb/label/experimental
 
 # List packages depending on `libtiledbsoma`:
-mamba repoquery whoneeds libtiledbsoma --channel tiledb
+mamba repoquery whoneeds libtiledbsoma --channel tiledb/label/experimental
 
 # List dependencies of `libtiledbsoma`:
-mamba repoquery depends libtiledbsoma --channel tiledb
+mamba repoquery depends libtiledbsoma --channel tiledb/label/experimental
 ```
 
 

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,14 +1,23 @@
 github:
   user_or_org: TileDB-Inc
-  branch_name: main
+  # FOR THIS PR ONLY
+  # branch_name: main
+  branch_name: ss/test-linux-arm64
+  store_build_artifacts: true
   tooling_branch_name: main
 build_platform:
+  linux_aarch64: linux_64
   osx_arm64: osx_64
 conda_forge_output_validation: true
 test: native_and_emulated
 # build_with_mambabuild: false
-upload_on_branch: main
+# FOR THIS PR
+# upload_on_branch: main
+upload_on_branch: ss/test-linux-arm64
 azure:
   build_id: 43
   user_or_org: TileDB-Inc
   project_name: CI
+channel_priority: flexible
+provider:
+  linux_aarch64: default

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -2,7 +2,7 @@ github:
   user_or_org: TileDB-Inc
   # FOR THIS PR ONLY
   # branch_name: main
-  branch_name: ss/test-linux-arm64
+  branch_name: dev
   store_build_artifacts: true
   tooling_branch_name: main
 build_platform:
@@ -13,7 +13,7 @@ test: native_and_emulated
 # build_with_mambabuild: false
 # FOR THIS PR
 # upload_on_branch: main
-upload_on_branch: ss/test-linux-arm64
+upload_on_branch: dev
 azure:
   build_id: 43
   user_or_org: TileDB-Inc

--- a/recipe/build-r-tiledbsoma.sh
+++ b/recipe/build-r-tiledbsoma.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+echo
+echo
+echo "================================================================"
+echo "ENTER recipe/build-r-tiledbsoma.sh"
+echo
+echo
+
 set -ex
 
 cd apis/r
@@ -25,6 +32,28 @@ if [[ $target_platform == osx-*  ]]; then
   CXXFLAGS="${CXXFLAGS} -D_LIBCPP_DISABLE_AVAILABILITY"
 fi
 
+echo
+echo "----------------------------------------------------------------"
+echo "CXXFLAGS   <<${CXXFLAGS}>>"
+echo "CXX17FLAGS <<${CXX17FLAGS}>>"
+echo
+
+echo
+echo "----------------------------------------------------------------"
+echo "CAT ./TOOLS/BUILD_LIBTILEDBSOMA.SH.IN"
+cat ./tools/build_libtiledbsoma.sh.in
+echo
+
+echo
+echo "----------------------------------------------------------------"
+echo "CAT ./TOOLS/BUILD_LIBTILEDBSOMA.SH"
+if [ -f ./tools/build_libtiledbsoma.sh ]; then
+  cat ./tools/build_libtiledbsoma.sh
+else
+  echo NOT FOUND ./tools/build_libtiledbsoma.sh
+fi
+echo
+
 # Unlike most R recipes which are built for one R version per job, this recipe
 # with multiple outputs builds for each of the R versions in the same job. Thus
 # the compiled files in the source directory need to be cleaned between builds,
@@ -48,4 +77,26 @@ if [ ${res} != "TRUE" ]; then
   exit 1
 fi
 
+echo
+echo "----------------------------------------------------------------"
+echo "RES <<${res}>>"
+echo
+
+echo
+echo "----------------------------------------------------------------"
+echo "BEFORE R CMD INSTALL"
+echo
+
 ${R} CMD INSTALL ${R_ARGS_EXTRA} --build . ${R_ARGS}
+
+echo
+echo "----------------------------------------------------------------"
+echo "AFTER R CMD INSTALL"
+echo
+
+echo
+echo "----------------------------------------------------------------"
+echo "LOOK FOR .SO FILES"
+echo
+
+ls -l $(find . -name '*.so' -print)

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,24 +4,35 @@ MACOSX_SDK_VERSION:  # [osx and x86_64]
 MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
   - "11.0"                # [osx and x86_64]
 channel_sources:
-  - tiledb/label/for-cloud,conda-forge,tiledb  # [linux]
+  - tiledb/label/for-cloud,conda-forge,tiledb  # [linux and x86]
   - conda-forge,tiledb
 channel_targets:
-  - tiledb main
+  # FOR THIS PR
+  # - tiledb main
+  - tiledb experimental
 channel_priority:
   - strict
+# What follows is the "non-default stuff" block.
+#
+# We are telling conda-smithy that we want two different builds of linux-64:
+# * standard: fmt 10, spdlog 1.12, tiledb channel
+# * special for-cloud: fmt 9, spdlog 1.11, tiledb/label/for-cloud channel
+# * For all the other builds: osx-64, osx-arm64, linux-aarch64, we just want conda-smithy to create
+#   a single build with the current default pinnings
+#
 # conda-forge has migrated to fmt 10 and spdlog 1.12. We need fmt 9 to install
 # into our existing TileDB Cloud conda environments, so we build a special
 # variant of fmt 9 and spdlog 1.11. And because this can no longer solve with
-# conda-forge depedencies, we install the "for-cloud" tiledb binary from
-# tiledb/label/for-cloud
-fmt:                 # [linux]
-  - 9                # [linux]
-  - 10               # [linux]
-spdlog:              # [linux]
-  - 1.11             # [linux]
-  - 1.12             # [linux]
-zip_keys:            # [linux]
-  - channel_sources  # [linux]
-  - fmt              # [linux]
-  - spdlog           # [linux]
+# conda-forge depedencies, we install the "for-cloud" statically linked
+# tiledb binary from tiledb/label/for-cloud -- see also 
+# https://github.com/TileDB-Inc/tiledb-feedstock-for-cloud
+fmt:                 # [linux and x86]
+  - 9                # [linux and x86]
+  - 10               # [linux and x86]
+spdlog:              # [linux and x86]
+  - 1.11             # [linux and x86]
+  - 1.12             # [linux and x86]
+zip_keys:            # [linux and x86]
+  - channel_sources  # [linux and x86]
+  - fmt              # [linux and x86]
+  - spdlog           # [linux and x86]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.10.1" %}
-{% set sha256 = "a3bff197b3961c4d19a4196ad5361d66a14b61d71cb8916f326e4d2a8738bf3b" %}
+{% set version = "1.10.2" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,16 +16,17 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 74afcca3a5b1517c994e790b539ea6249b6fa74b
-#  git_depth: -1
-#  # hoping to be i.j.k <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  # kerl/linux-arm64-conda-debug branch of single-cell-data/TileDB-SOMA
+  git_rev: b05e4db60741b1a94f9a0c9a094d5e2dcd02dc3a
+  git_depth: -1
+  # hoping to be i.j.k <-- FILL IN HERE
 
 build:
   number: 0
@@ -199,10 +200,15 @@ outputs:
         - r-nanoarrow
     test:
       commands:
+        - echo "BEGIN R TESTS"
         - $R -e "library('tiledbsoma')"
         - $R -e "tiledbsoma::show_package_versions()"
+        - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.dylib"  # [osx]
         - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.dylib | grep -e libR -e libtiledb"  # [osx]
-        - "ldd $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.so | grep -e libR -e libtiledb"  # [linux]
+        # `uname -a` here reveals that linux+aarch64 is actually cross-compiled from an x86 host.
+        # So we can't run `ldd` here; we get "not a dynamic executable" which fails the build.
+        - "ldd $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.so | grep -e libR -e libtiledb"  # [linux and x86]
+        - echo "END R TESTS"
     about:
       home: http://tiledb.com
       license: MIT


### PR DESCRIPTION
Just an application of #138 to `dev` rather than `main`.

Goal here: get linux+aarch64 files (and others as well) uploaded to https://anaconda.org/tiledb/tiledbsoma-py/files with label `experimental`.

I tried to rebase #138 to `dev` and it got messy; just doing a fresh copy here.