### PR TITLE
tiledbsoma 1.10.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -115,7 +115,7 @@ outputs:
         - numba          # [py<=37]
         - attrs >=22.2
         # Keep this in sync with TileDB-SOMA's somacore version requirement.
-        - somacore ==1.0.9
+        - somacore ==1.0.11
         - scanpy >=1.9.2
         # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
         - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.10.1" %}
-{% set sha256 = "a3bff197b3961c4d19a4196ad5361d66a14b61d71cb8916f326e4d2a8738bf3b" %}
+{% set version = "1.10.2" %}
+{% set sha256 = "7b098e13ff1b51a4a487ec3f17b3d56c8819bfac7341f31f770cd5e66559cb84" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

Needs https://github.com/TileDB-Inc/somacore-feedstock/pull/14