### PR TITLE
Rerender to fix nightly setup job

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -9,8 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     name: automerge
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
       - name: automerge-action
         id: automerge-action
         uses: conda-forge/automerge-action@main


### PR DESCRIPTION
Closes #147 

The latest round of changes from `conda smithy rerender` edits `.github/workflows/automerge.yml`. GitHub requires the token to have the `workflows` permission in order to edit a workflow file, and our token only has the standard write permission.

This PR performs the rerendering that edits `.github/workflows/automerge.yml`. This will unblock the nightly setup job since it will no longer edit the workflow file.