### PR TITLE
tiledbsoma 1.11.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.10.2" %}
-{% set sha256 = "7b098e13ff1b51a4a487ec3f17b3d56c8819bfac7341f31f770cd5e66559cb84" %}
+{% set version = "1.11.0" %}
+{% set sha256 = "f850ac995b585b8d476bdb9702887f03b2af55484c41859e4142b612b6500ad5" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -28,7 +28,7 @@ source:
 #  # hoping to be i.j.k <-- FILL IN HERE
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 
@@ -44,7 +44,7 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.22.0,<2.23
+        - tiledb >=2.23.0,<2.24
         - spdlog
         - fmt
       run:
@@ -107,7 +107,7 @@ outputs:
         - scipy
         - anndata       # [py>37]
         - anndata <0.9  # [py<=37]
-        - tiledb-py >=0.28.0,<0.29.0
+        - tiledb-py >=0.29.0,<0.30.0
         - typing-extensions >=4.1
         - numba >=0.58.1 # [py>37]
         - numba          # [py<=37]
@@ -148,7 +148,7 @@ outputs:
         - r-matrix                   # [build_platform != target_platform]
         - r-bit64                    # [build_platform != target_platform]
         - r-rcppint64                # [build_platform != target_platform]
-        - r-tiledb >=0.26.0,<0.27    # [build_platform != target_platform]
+        - r-tiledb >=0.27.0,<0.28    # [build_platform != target_platform]
         - r-arrow                    # [build_platform != target_platform]
         - r-fs                       # [build_platform != target_platform]
         - r-glue                     # [build_platform != target_platform]
@@ -167,7 +167,7 @@ outputs:
         - r-matrix
         - r-bit64
         - r-rcppint64
-        - r-tiledb >=0.26.0,<0.27
+        - r-tiledb >=0.27.0,<0.28
         - r-arrow
         - r-fs
         - r-glue
@@ -184,7 +184,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64
-        - r-tiledb >=0.26.0,<0.27
+        - r-tiledb >=0.27.0,<0.28
         - r-arrow
         - r-fs
         - r-glue


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)