### PR TITLE
Fix linux-64 nightly errors

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -17,7 +17,7 @@ sed -i \
 
 # Build the latest commit on "main" branch
 sed -i \
-  s/"sha256: .\+"/"git_rev: main\n  git_depth: 1"/ \
+  s/"sha256: .\+"/"git_rev: main\n  git_depth: -1"/ \
   recipe/meta.yaml
 
 git --no-pager diff recipe/meta.yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -96,7 +96,7 @@ outputs:
         - pyarrow       # [not osx]
         - pyarrow-hotfix
       run:
-        - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.24') }}
+        - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.27') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - pandas
         # https://github.com/single-cell-data/TileDB-SOMA/issues/1926


### PR DESCRIPTION
* Perform unshallow clone for updated version.py
* Bump numpy upper bound for python 3.12 which uses 1.26

Unfortunately the nightly osx-* builds are still broken

xref: https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/153