### PR TITLE
Remove lower bound on pyarrow

### DIFF
--- a/.ci_support/linux_64_fmt10spdlog1.13.yaml
+++ b/.ci_support/linux_64_fmt10spdlog1.13.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -47,6 +51,8 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - channel_sources
   - fmt
   - spdlog

--- a/.ci_support/linux_64_fmt10spdlog1.13.yaml
+++ b/.ci_support/linux_64_fmt10spdlog1.13.yaml
@@ -29,6 +29,8 @@ pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
+pyarrow:
+- '16'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
@@ -48,5 +50,6 @@ zip_keys:
 - - channel_sources
   - fmt
   - spdlog
+  - pyarrow
 - - python
   - numpy

--- a/.ci_support/linux_64_fmt9spdlog1.11.yaml
+++ b/.ci_support/linux_64_fmt9spdlog1.11.yaml
@@ -2,6 +2,10 @@ c_compiler:
 - gcc
 c_compiler_version:
 - '12'
+c_stdlib:
+- sysroot
+c_stdlib_version:
+- '2.12'
 cdt_name:
 - cos6
 channel_sources:
@@ -47,6 +51,8 @@ target_platform:
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version
+- - c_stdlib_version
+  - cdt_name
 - - channel_sources
   - fmt
   - spdlog

--- a/.ci_support/linux_64_fmt9spdlog1.11.yaml
+++ b/.ci_support/linux_64_fmt9spdlog1.11.yaml
@@ -29,6 +29,8 @@ pin_run_as_build:
   r-base:
     min_pin: x.x
     max_pin: x.x
+pyarrow:
+- '11'
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
@@ -48,5 +50,6 @@ zip_keys:
 - - channel_sources
   - fmt
   - spdlog
+  - pyarrow
 - - python
   - numpy

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -21,6 +21,7 @@ macos_machine:
 numpy:
 - '1.22'
 - '1.23'
+- '1.26'
 - '1.22'
 - '1.22'
 pin_run_as_build:
@@ -33,6 +34,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.12.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 r_base:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge,tiledb
 channel_targets:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -21,6 +21,7 @@ macos_machine:
 numpy:
 - '1.22'
 - '1.23'
+- '1.26'
 - '1.22'
 - '1.22'
 pin_run_as_build:
@@ -33,6 +34,7 @@ pin_run_as_build:
 python:
 - 3.10.* *_cpython
 - 3.11.* *_cpython
+- 3.12.* *_cpython
 - 3.8.* *_cpython
 - 3.9.* *_cpython
 r_base:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -6,6 +6,10 @@ c_compiler:
 - clang
 c_compiler_version:
 - '16'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
 channel_sources:
 - conda-forge,tiledb
 channel_targets:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -21,10 +21,14 @@ fmt:                 # [linux]
 spdlog:              # [linux]
   - 1.11             # [linux]
   - 1.13             # [linux]
+pyarrow:             # [linux]
+  - 11               # [linux]
+  - 16               # [linux]
 zip_keys:            # [linux]
   - channel_sources  # [linux]
   - fmt              # [linux]
   - spdlog           # [linux]
+  - pyarrow          # [linux]
 # Because of the awkwardness required for the cloud variant above
 # (fmt9+spdlog1.11), we have to migrate the osx-* manually here. Once the
 # conda-forge-pinning-feedstock is updated to spdlog 1.13, we can remove the

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,8 +1,9 @@
 # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
+# https://conda-forge.org/news/2024/03/24/stdlib-migration/
 MACOSX_SDK_VERSION:  # [osx and x86_64]
   - 11.0            # [osx and x86_64]
-MACOSX_DEPLOYMENT_TARGET:  # [osx and x86_64]
-  - "11.0"                # [osx and x86_64]
+c_stdlib_version:              # [osx and x86_64]
+  - 11.0                       # [osx and x86_64]
 channel_sources:
   - tiledb/label/for-cloud,conda-forge,tiledb  # [linux]
   - conda-forge,tiledb

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -35,22 +35,3 @@ zip_keys:            # [linux]
 # manual pin below
 spdlog:              # [not linux]
   - 1.13             # [not linux]
-# The below prevents a Python 3.12 variant for the osx-* builds. We can't build
-# tiledbsoma-py for Python 3.12 on osx-* until the AWS/S3 problem introduced in
-# pyarrow 13 is resolved
-# https://github.com/single-cell-data/TileDB-SOMA/issues/1926#issuecomment-1834695149
-python:               # [osx]
-  - 3.8.* *_cpython   # [osx]
-  - 3.9.* *_cpython   # [osx]
-  - 3.10.* *_cpython  # [osx]
-  - 3.11.* *_cpython  # [osx]
-python_impl:          # [osx]
-  - cpython           # [osx]
-  - cpython           # [osx]
-  - cpython           # [osx]
-  - cpython           # [osx]
-numpy:                # [osx]
-  - 1.22              # [osx]
-  - 1.22              # [osx]
-  - 1.22              # [osx]
-  - 1.23              # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -40,6 +40,7 @@ outputs:
       build:
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
+        - {{ stdlib("c") }}
         - git
         - cmake
         - make  # [not win]
@@ -72,6 +73,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
+        - {{ stdlib("c") }}
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
@@ -116,8 +118,6 @@ outputs:
         # Keep this in sync with TileDB-SOMA's somacore version requirement.
         - somacore ==1.0.11
         - scanpy >=1.9.2
-        # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
     test:
       imports:
         - tiledbsoma
@@ -148,6 +148,7 @@ outputs:
     requirements:
       build:
         - {{ compiler('cxx') }}
+        - {{ stdlib("c") }}
         - pkg-config
         # required for cross-compilation
         - cross-r-base {{ r_base }}  # [build_platform != target_platform]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
 #  # hoping to be 1.12.0 <-- FILL IN HERE
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -75,10 +75,10 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
-        - pyarrow                         # [build_platform != target_platform]
+        - pyarrow                                # [build_platform != target_platform]
         # Needed until https://github.com/single-cell-data/TileDB-SOMA/issues/1926 is resolved,
         # when the repo's own setup.py won't depend on pyarrow-hotfix anymore
-        - pyarrow-hotfix
+        - pyarrow-hotfix                         # [build_platform != target_platform]
         - numpy                                  # [build_platform != target_platform]
       host:
         - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -74,7 +74,7 @@ outputs:
         - python                                 # [build_platform != target_platform]
         - cross-python_{{ target_platform }}     # [build_platform != target_platform]
         - pybind11                               # [build_platform != target_platform]
-        - pyarrow >=14.0                         # [build_platform != target_platform]
+        - pyarrow                         # [build_platform != target_platform]
         # Needed until https://github.com/single-cell-data/TileDB-SOMA/issues/1926 is resolved,
         # when the repo's own setup.py won't depend on pyarrow-hotfix anymore
         - pyarrow-hotfix
@@ -91,7 +91,7 @@ outputs:
         - setuptools_scm
         - wheel
         - numpy
-        - pyarrow >=14.0
+        - pyarrow
         # Needed until https://github.com/single-cell-data/TileDB-SOMA/issues/1926 is resolved,
         # when the repo's own setup.py won't depend on pyarrow-hotfix anymore
         - pyarrow-hotfix
@@ -99,7 +99,7 @@ outputs:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.27') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - pandas
-        - pyarrow >=14.0
+        - pyarrow
         # Needed until https://github.com/single-cell-data/TileDB-SOMA/issues/1926 is resolved,
         # when the repo's own setup.py won't depend on pyarrow-hotfix anymore
         - pyarrow-hotfix

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,6 +68,7 @@ outputs:
     version: {{ version }}
     script: build-tiledbsoma-py.sh
     build:
+      skip: true  # [py == 312]
     requirements:
       build:
         - {{ compiler('cxx') }}


### PR DESCRIPTION
Followup to #174. In that PR, we set the lower bound `pyarrow >= 14`. However, we can't do this because TileDB Cloud still has pyarrow 11 installed.

This PR:

* Fixes the conda solver problem by removing the lower bound on pyarrow
* In addition it purposefully builds against pyarrow 11. This is a bit overkill since pyarrow doesn't use run exports. However, I wanted to be confident that it could solve an env with pyarrow 11. We could relax this part in the future
* Completely skip the Python 3.12 builds. We don't need them now, and it is too much trouble at the moment. Once we relax the above, we can probably add them back
* Stopped pyarrrow-hotfix from being installed in the non-cross-compiled build envs
* Migrated the recipe to use [`- {{ stdlib("c") }`](https://conda-forge.org/news/2024/03/24/stdlib-migration/). I've been meaning to do this for awhile

All the builds passed on my [fork](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=852&view=results)