### PR TITLE
Remove remaining uses of MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -48,9 +48,6 @@ outputs:
         - tiledb >=2.24.0,<2.25
         - spdlog
         - fmt
-      run:
-        # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
     about:
       home: http://tiledb.com
       license: MIT
@@ -166,8 +163,6 @@ outputs:
         - r-data.table               # [build_platform != target_platform]
         - r-rlang                    # [build_platform != target_platform]
         - r-nanoarrow                # [build_platform != target_platform]
-        # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
-        - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}  # [osx and x86_64]
       host:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base


### PR DESCRIPTION
Followup to #176. I had removed `__osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.9") }}` from the Python requirements, but I forgot to remove it from the C++ and R requirements.

I didn't bump the build number. These lines don't hurt anything; they are just unnecessary clutter now that we've migrated to `{{ stdlib("c") }}`.

Rerendering had no effect.