### PR TITLE
[ci skip] Use "nightly" label for nightly builds when using "rc" label

### DIFF
--- a/.github/scripts/nightly/update-feedstock.sh
+++ b/.github/scripts/nightly/update-feedstock.sh
@@ -10,6 +10,11 @@ sed -i \
 sed -i \
   s/"tiledb main"/"tiledb nightlies"/ \
   recipe/conda_build_config.yaml
+# Cover edge case when the label "rc" is temporarily used to upload release
+# candidates
+sed -i \
+  s/"tiledb rc"/"tiledb nightlies"/ \
+  recipe/conda_build_config.yaml
 
 # Print differences
 git --no-pager diff conda-forge.yml recipe/conda_build_config.yaml


### PR DESCRIPTION
Back in October 2023, we temporarily used the label "rc" to upload release candidates to anaconda.org. The nightly builds need to use the label "nightly" in order to be properly [deleted](https://github.com/TileDB-Inc/conda-forge-nightly-controller/blob/main/.github/workflows/delete-old-nightlies.yml) later. Because the subsitution is done with a simple `sed` call, this caused many nightly binaries to be uploaded with the label "rc" and never deleted, taking up valuable storage space.

This PR simply adds a second `sed` call to catch this edge case in the future.

xref: label "rc" added in #46, reverted to "main" in #58