### PR TITLE
tiledbsoma 1.14.2 hash-fix

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
 {% set version = "1.14.2" %}
-{% set sha256 = "tbd" %}
+{% set sha256 = "b459976562fdea0c5a2ae03843b44e82e0a1d1f0721f3452d19ba49ad8d62231" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,19 +16,19 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-#source:
-#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-#  sha256: {{ sha256 }}
+source:
+  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-source:
-  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  git_rev: 2d5d705b020f2996a9266fe9268732f7c440cc37
-  git_depth: -1
-  # hoping to be 1.14.2 <-- FILL IN HERE
+#source:
+#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+#  git_rev: 2d5d705b020f2996a9266fe9268732f7c440cc37
+#  git_depth: -1
+#  # hoping to be 1.14.2 <-- FILL IN HERE
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 


### PR DESCRIPTION
#202 contained a copy-paste from the pre-check PR #201 of the sha/hash info. I forgot to update to the released hash on 202. This PR fixes that.

I noticed this while testing https://github.com/TileDB-Inc/TileDB-REST-UDF-Docker-Images/pull/721 following our [established procedure](https://www.notion.so/785d165226074071872a8b797133d36c?v=c168da78516e487eac3746d38924fa97&p=d1c7a37761b04cf699a705bb8963dea9&pm=s) -- on-image I found

```
tiledbsoma.__version__              1.14.1.post3.dev12177573296
TileDB core version (libtiledbsoma) 2.26.1
python version                      3.9.19.final.0
OS version                          Linux 6.8.0-1016-aws
```

The `1.14.1.post3.dev12177573296` needs to be `1.14.2`.

https://github.com/single-cell-data/TileDB-SOMA/issues/3075
[[sc-56256]](https://app.shortcut.com/tiledb-inc/story/56256/tiledb-soma-1-14-2)