### PR TITLE
Install cctools in test section for `otool` in macOS-13 image

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -203,6 +203,7 @@ outputs:
         # Confirm 2.26.2 can be installed at runtime. Remove when migrating to
         # 2.27
         - tiledb >=2.26.2,<2.27
+        - cctools  # [osx]
       commands:
         - $R -e "library('tiledbsoma')"
         - $R -e "tiledbsoma::show_package_versions()"


### PR DESCRIPTION
Closes #208 

`otool` isn't available in the new macOS-13 image (for more details see https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/208#issuecomment-2414485496)

Successfully built on my fork in https://github.com/jdblischak/tiledbsoma-feedstock/commit/351bee218d82ba555685f5f3aa303864c1e975be

Not actually needed for osx-arm64 at the moment, but figured I'd rather be safe than sorry (in other words, no way to know if or when `otool` may disappear from a future arm64 image).

No need to bump build number. This only affects the test section, and is simply to fix the broken osx-64 nightly.