### PR TITLE
Bump somacore to 1.0.21 for nightly feedstock builds

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -22,7 +22,7 @@ sed -i \
 
 # (Temporary) Bump somacore
 sed -i \
-  s/"somacore ==.\+"/"somacore ==1.0.20"/ \
+  s/"somacore ==.\+"/"somacore ==1.0.21"/ \
   recipe/meta.yaml
 
 git --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Closes #210

xref: #205, https://github.com/single-cell-data/TileDB-SOMA/pull/3188