### PR TITLE
tiledbsoma 1.14.5 pre-check

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.14.2" %}
-{% set sha256 = "b459976562fdea0c5a2ae03843b44e82e0a1d1f0721f3452d19ba49ad8d62231" %}
+{% set version = "1.14.5" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,16 +16,16 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 2d5d705b020f2996a9266fe9268732f7c440cc37
-#  git_depth: -1
-#  # hoping to be 1.14.2 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: afca166d73cf97a0daf5e73ba6ce976064de0018
+  git_depth: -1
+  # hoping to be 1.14.5 <-- FILL IN HERE
 
 build:
   number: 1


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

[[sc-58115]](https://app.shortcut.com/tiledb-inc/story/58115/reading-obs-previously-updated-errors)