### PR TITLE
[ci skip] Bump somacore to 1.0.23 for nightly feedstock builds

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -22,7 +22,7 @@ sed -i \
 
 # (Temporary) Bump somacore
 sed -i \
-  s/"somacore ==.\+"/"somacore ==1.0.22"/ \
+  s/"somacore ==.\+"/"somacore ==1.0.23"/ \
   recipe/meta.yaml
 
 git --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Closes #221 

Trying out the new conda-forge feedstock behavior to be able to skip CI jobs in a PR 🤞 

xref: https://github.com/single-cell-data/TileDB-SOMA/pull/3274