### PR TITLE
Test upstream branch release-1.15

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
 - '11'
 numpy:
@@ -43,8 +43,6 @@ spdlog:
 - '1.14'
 target_platform:
 - linux-64
-tiledb:
-- '2.26'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -45,8 +45,6 @@ spdlog:
 - '1.14'
 target_platform:
 - osx-64
-tiledb:
-- '2.26'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -45,8 +45,6 @@ spdlog:
 - '1.14'
 target_platform:
 - osx-arm64
-tiledb:
-- '2.26'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,18 +17,18 @@ package:
 
 # Post-tag real thing:
 source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  # url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  # sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
 #source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 20485c793829a15e27d01bb320bea290c561f46d
-#  git_depth: -1
+ git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+ git_rev: release-1.15
+ git_depth: -1
 #  # hoping to be 1.15.0rc3 <-- FILL IN HERE
 
 build:
-  number: 1
+  number: 0
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 
@@ -102,7 +102,7 @@ outputs:
         - numba >=0.58.1
         - attrs >=22.2
         # Keep this in sync with TileDB-SOMA's somacore version requirement.
-        - somacore ==1.0.22
+        - somacore ==1.0.24
         - scanpy >=1.9.2
     test:
       imports:
@@ -144,7 +144,7 @@ outputs:
         - pkg-config
         # required for cross-compilation
         - cross-r-base {{ r_base }}  # [build_platform != target_platform]
-        - r-rcppspdlog               # [build_platform != target_platform]
+        - r-rcppspdlog >=0.0.19      # [build_platform != target_platform]
         - r-matrix                   # [build_platform != target_platform]
         - r-bit64                    # [build_platform != target_platform]
         - r-rcppint64                # [build_platform != target_platform]


### PR DESCRIPTION
This demonstrates that the upstream branch release-1.15, which uses C++17, can be compiled in the conda feedstock.

This is only for documentation purposes and should not be merged.

Also note that we will still need to create a pre-check PR once tiledb 2.27 is available as a conda binary.

xref: https://github.com/single-cell-data/TileDB-SOMA/pull/3389, https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/234