### PR TITLE
Update `py39cloud` variant to 1.15.0

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,7 +11,7 @@ jobs:
       linux_64_:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
   timeoutInMinutes: 360
   variables: {}
 

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -17,7 +17,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '13'
 docker_image:
-- quay.io/condaforge/linux-anvil-cos7-x86_64
+- quay.io/condaforge/linux-anvil-x86_64:alma9
 fmt:
 - '9'
 numpy:
@@ -39,8 +39,6 @@ spdlog:
 - '1.11'
 target_platform:
 - linux-64
-tiledb:
-- '2.26'
 zip_keys:
 - - c_compiler_version
   - cxx_compiler_version

--- a/build-locally.py
+++ b/build-locally.py
@@ -26,6 +26,13 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
+    # The default cache location might not be writable using docker on macOS.
+    if ns.config.startswith("linux") and platform.system() == "Darwin":
+        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
+            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
+            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
+        )
+
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.0rc3" %}
-{% set sha256 = "66c1b3ea9ea3251e7b51714f7087ad7b43096b42dff49032e0df96b601262da1" %}
+{% set version = "1.15.0" %}
+{% set sha256 = "c2932a6f639e596a1a1c8bd3c0cc7e0b5e034a888420025f38b3dbec177f206e" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -23,9 +23,10 @@ source:
 # Pre-tag canary "will Conda be green if we release":
 #source:
 #  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  git_rev: 20485c793829a15e27d01bb320bea290c561f46d
+#  # release-1.15 branch 2024-12-16
+#  git_rev: e5d19d05b659cd04f43e5b4a227ace8b5e676815
 #  git_depth: -1
-#  # hoping to be 1.15.0rc3 <-- FILL IN HERE
+#  # hoping to be 1.15.0 <-- FILL IN HERE
 
 build:
   number: 0
@@ -45,7 +46,7 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.26.0,<2.27
+        - tiledb >=2.27.0,<2.28
         - spdlog
         - fmt
     about:
@@ -93,20 +94,21 @@ outputs:
         - pandas
         - pyarrow
         - python
-        - scipy
+        # https://github.com/single-cell-data/TileDB-SOMA/issues/3444
+        - scipy <1.15.0
         - anndata >=0.10.1
-        - tiledb-py >=0.32.0,<0.33.0
         - typing-extensions >=4.1
         - numba >=0.58.1
         - attrs >=22.2
         # Keep this in sync with TileDB-SOMA's somacore version requirement.
-        - somacore ==1.0.22
+        - somacore ==1.0.26
         - scanpy >=1.9.2
     test:
       imports:
         - tiledbsoma
       requires:
         - pip
+        - tiledb-py >=0.33.0,<0.34.0
       commands:
         - python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())'
         # See also:
@@ -139,11 +141,11 @@ outputs:
         - pkg-config
         # required for cross-compilation
         - cross-r-base {{ r_base }}  # [build_platform != target_platform]
-        - r-rcppspdlog               # [build_platform != target_platform]
+        - r-rcppspdlog >=0.0.19      # [build_platform != target_platform]
         - r-matrix                   # [build_platform != target_platform]
         - r-bit64                    # [build_platform != target_platform]
         - r-rcppint64                # [build_platform != target_platform]
-        - r-tiledb >=0.30.0,<0.31    # [build_platform != target_platform]
+        - r-tiledb >=0.31.0,<0.32    # [build_platform != target_platform]
         - r-arrow                    # [build_platform != target_platform]
         - r-fs                       # [build_platform != target_platform]
         - r-glue                     # [build_platform != target_platform]
@@ -160,7 +162,7 @@ outputs:
         - r-matrix
         - r-bit64
         - r-rcppint64
-        - r-tiledb >=0.30.0,<0.31
+        - r-tiledb >=0.31.0,<0.32
         - r-arrow
         - r-fs
         - r-glue
@@ -177,7 +179,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64
-        - r-tiledb >=0.30.0,<0.31
+        - r-tiledb >=0.31.0,<0.32
         - r-arrow
         - r-fs
         - r-glue


### PR DESCRIPTION
Closes #229

Companion to #238 

[[sc-59686]](https://app.shortcut.com/tiledb-inc/story/59686/update-projects-to-tiledb-2-27)