### PR TITLE
tiledbsoma 1.15.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.0" %}
-{% set sha256 = "c2932a6f639e596a1a1c8bd3c0cc7e0b5e034a888420025f38b3dbec177f206e" %}
+{% set version = "1.15.1" %}
+{% set sha256 = "255b38ba009a522192113e21202650456d0084455eae8b105dc16b47c7725ab6" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -24,9 +24,9 @@ source:
 #source:
 #  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
 #  # release-1.15 branch 2024-12-16
-#  git_rev: e5d19d05b659cd04f43e5b4a227ace8b5e676815
+#  git_rev: f0b20b966ab3dfaee4c15c614dbe53770b197312
 #  git_depth: -1
-#  # hoping to be 1.15.0 <-- FILL IN HERE
+#  # hoping to be 1.15.1 <-- FILL IN HERE
 
 build:
   number: 0


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

[[sc-59686]](https://app.shortcut.com/tiledb-inc/story/59686/update-projects-to-tiledb-2-27)