### PR TITLE
C++20 R build

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -18,8 +18,6 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
-fmt:
-- '11'
 numpy:
 - '2.0'
 - '2.0'
@@ -40,7 +38,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.14'
+- '1.15'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -40,7 +40,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.14'
+- '1.15'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -18,6 +18,8 @@ cxx_compiler_version:
 - '13'
 docker_image:
 - quay.io/condaforge/linux-anvil-x86_64:alma9
+fmt:
+- '11'
 numpy:
 - '2.0'
 - '2.0'
@@ -38,7 +40,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.15'
+- '1.14'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/migrations/spdlog115.yaml
+++ b/.ci_support/migrations/spdlog115.yaml
@@ -1,0 +1,9 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for spdlog 1.15
+  kind: version
+  migration_number: 1
+migrator_ts: 1731195190.0405502
+spdlog:
+- '1.15'
+

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -42,7 +42,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.14'
+- '1.15'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,5 +1,5 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '13.3'
+- '11.0'
 MACOSX_SDK_VERSION:
 - '13.3'
 c_compiler:
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -40,7 +42,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.15'
+- '1.14'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '13.3'
 MACOSX_SDK_VERSION:
-- '14.0'
+- '13.3'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '13.3'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '14.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
-fmt:
-- '11'
 macos_machine:
 - x86_64-apple-darwin13.4.0
 numpy:
@@ -42,7 +40,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.14'
+- '1.15'
 target_platform:
 - osx-64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '13.3'
 MACOSX_SDK_VERSION:
-- '14.0'
+- '13.3'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -42,7 +42,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.14'
+- '1.15'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '13.3'
+- '11.0'
 MACOSX_SDK_VERSION:
-- '13.3'
+- '11.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,6 +18,8 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
+fmt:
+- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -40,7 +42,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.15'
+- '1.14'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
-- '11.0'
+- '13.3'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '14.0'
 c_compiler:
 - clang
 c_compiler_version:
@@ -18,8 +18,6 @@ cxx_compiler:
 - clangxx
 cxx_compiler_version:
 - '18'
-fmt:
-- '11'
 macos_machine:
 - arm64-apple-darwin20.0.0
 numpy:
@@ -42,7 +40,7 @@ python:
 r_base:
 - '4.3'
 spdlog:
-- '1.14'
+- '1.15'
 target_platform:
 - osx-arm64
 zip_keys:

--- a/recipe/build-libtiledbsoma.sh
+++ b/recipe/build-libtiledbsoma.sh
@@ -3,7 +3,7 @@
 set -exo pipefail
 
 # Clear default compiler flags
-export CXXFLAGS=""
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
 
 mkdir libtiledbsoma-build && cd libtiledbsoma-build
 

--- a/recipe/build-libtiledbsoma.sh
+++ b/recipe/build-libtiledbsoma.sh
@@ -2,6 +2,9 @@
 
 set -exo pipefail
 
+# Clear default compiler flags
+export CXXFLAGS=""
+
 mkdir libtiledbsoma-build && cd libtiledbsoma-build
 
 cmake \

--- a/recipe/build-r-tiledbsoma.sh
+++ b/recipe/build-r-tiledbsoma.sh
@@ -5,7 +5,7 @@ set -ex
 cd apis/r
 
 # Clear default compiler flags
-export CXXFLAGS=""
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
 
 export DISABLE_AUTOBREW=1
 

--- a/recipe/build-r-tiledbsoma.sh
+++ b/recipe/build-r-tiledbsoma.sh
@@ -10,7 +10,7 @@ export CXXFLAGS=""
 export DISABLE_AUTOBREW=1
 
 # https://github.com/conda-forge/r-tiledb-feedstock/commit/29cb6816636e7b5b58545e1407a8f0c29ff9dc39
-if [[ $target_platform  == osx-64 ]]; then
+if [[ $target_platform == osx-* ]]; then
   export NN_CXX_ORIG=$CXX
   export NN_CC_ORIG=$CC
   export CXX=$RECIPE_DIR/cxx_wrap.sh

--- a/recipe/build-r-tiledbsoma.sh
+++ b/recipe/build-r-tiledbsoma.sh
@@ -4,6 +4,9 @@ set -ex
 
 cd apis/r
 
+# Clear default compiler flags
+export CXXFLAGS=""
+
 export DISABLE_AUTOBREW=1
 
 # https://github.com/conda-forge/r-tiledb-feedstock/commit/29cb6816636e7b5b58545e1407a8f0c29ff9dc39
@@ -12,13 +15,18 @@ if [[ $target_platform  == osx-64 ]]; then
   export NN_CC_ORIG=$CC
   export CXX=$RECIPE_DIR/cxx_wrap.sh
   export CC=$RECIPE_DIR/cc_wrap.sh
-  mkdir -p ~/.R
-  echo CC=$RECIPE_DIR/cc_wrap.sh > ~/.R/Makevars
-  echo CXX=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
-  echo CXX17=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
+  export CXX20=$RECIPE_DIR/cxx_wrap.sh
 fi
 
-export CXX17FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
+export CXX="$CXX -std=c++20 -fPIC"
+export CXX20="$CXX"
+
+mkdir -p ~/.R
+echo CC="$CC" > ~/.R/Makevars
+echo CXX="$CXX" >> ~/.R/Makevars
+echo CXX20="$CXX20" >> ~/.R/Makevars
+
+export CXX20FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
 
 # https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
 if [[ $target_platform == osx-*  ]]; then

--- a/recipe/build-tiledbsoma-py.sh
+++ b/recipe/build-tiledbsoma-py.sh
@@ -5,7 +5,7 @@ set -ex
 cd apis/python
 
 # Clear default compiler flags
-export CXXFLAGS=""
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
 
 echo
 echo "PKG_VERSION IS <<$PKG_VERSION>>"

--- a/recipe/build-tiledbsoma-py.sh
+++ b/recipe/build-tiledbsoma-py.sh
@@ -4,6 +4,9 @@ set -ex
 
 cd apis/python
 
+# Clear default compiler flags
+export CXXFLAGS=""
+
 echo
 echo "PKG_VERSION IS <<$PKG_VERSION>>"
 echo

--- a/recipe/cc_wrap.sh
+++ b/recipe/cc_wrap.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CC_ORIG $args -mmacosx-version-min=11.0
+args="${@##-mmacosx-version-min=13.3*}"
+$NN_CC_ORIG $args -mmacosx-version-min=13.3

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
 # https://conda-forge.org/news/2024/03/24/stdlib-migration/
-MACOSX_SDK_VERSION:  # [osx and x86_64]
-  - 14.0            # [osx and x86_64]
+MACOSX_SDK_VERSION:            # [osx and x86_64]
+  - 13.3                       # [osx and x86_64]
 c_stdlib_version:              # [osx and x86_64]
   - 11.0                       # [osx and x86_64]
 channel_sources:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
 # https://conda-forge.org/news/2024/03/24/stdlib-migration/
 MACOSX_SDK_VERSION:  # [osx and x86_64]
-  - 11.0            # [osx and x86_64]
+  - 14.0            # [osx and x86_64]
 c_stdlib_version:              # [osx and x86_64]
   - 11.0                       # [osx and x86_64]
 channel_sources:

--- a/recipe/cxx_wrap.sh
+++ b/recipe/cxx_wrap.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CXX_ORIG $args -mmacosx-version-min=11.0
+args="${@##-mmacosx-version-min=13.3*}"
+$NN_CXX_ORIG $args -mmacosx-version-min=13.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,12 @@ package:
 
 # Post-tag real thing:
 source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  # url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  # sha256: {{ sha256 }}
+  # Troubleshoot C++20 by pulling latest from main (just like the nightly builds)
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  git_rev: main
+  git_depth: -1
 
 # Pre-tag canary "will Conda be green if we release":
 #source:


### PR DESCRIPTION
After switching to C++20 the R build failed with an cryptic memory error message during build (see #230). The culprit seems to be `-fvisibility-inlines-hidden`, where the build succeeds once the flag is removed. With C++17 there is no issue with that flag and I haven't succeeded in a local repro of the issue outside of a docker container.