### PR TITLE
Add new conda-forge key `is_python_min` to fix rerendering

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -16,3 +16,5 @@ numpy:
   - 1.22
 python_impl:
   - cpython
+is_python_min:
+  - true


### PR DESCRIPTION
Background:

* We use `conda_build_config.yaml` to restrict the cloud build to only a py39 variant
* conda-forge added a new global pin `is_python_min` to their [global pinning file](https://github.com/conda-forge/conda-forge-pinning-feedstock/blob/5c1ec81641eaa369551d013939ddae864efe92d9/recipe/conda_build_config.yaml#L840), which is `# part of a zip_keys: python, python_impl, numpy, is_python_min`
* If we don't define all the zip keys, then our configuration is ignored, and thus `conda smithy rerender` tries to add all the Python variants supported by conda-forge
* This is what caused the problem yesterday in https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/256
* I first learned about this problem 2 weeks ago when it broke our nightly tiledb-py-feedstock builds (where we also restrict the Python variants) (https://github.com/TileDB-Inc/conda-forge-nightly-controller/issues/162, https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/163)

The fix is to define `is_python_min` in our `conda_build_config.yaml`. Now rerendering has no effect (below what I saw when running locally):

```sh
conda smithy rerender --commit auto
INFO:conda_smithy.configure_feedstock:README rendering is skipped
INFO:conda_smithy.configure_feedstock:__pycache__ rendering is skipped
WARNING: Setting build platform. This is only useful when pretending to be on another platform, such as for rendering necessary dependencies on a non-native platform. I trust that you know what you're doing.
WARNING: Setting build arch. This is only useful when pretending to be on another arch, such as for rendering necessary dependencies on a non-native arch. I trust that you know what you're doing.
WARNING: No numpy version specified in conda_build_config.yaml.  Falling back to default numpy value of 1.22
Adding in variants from internal_defaults
Adding in variants from /home/wsl/.cache/conda-smithy/conda_build_config.yaml
Adding in variants from /home/wsl/repos/tiledbsoma-feedstock/recipe/conda_build_config.yaml
Adding in variants from argument_variants
subpackages_about [('tiledbsoma', {'home': 'http://tiledb.com', 'license': 'MIT', 'license_family': 'MIT', 'license_file': 'LICENSE', 'summary': 'TileDB-SOMA API', 'description': 'Efficient storage and retrieval of single-cell data using TileDB', 'doc_url': 'https://docs.tiledb.com/', 'dev_url': 'https://github.com/single-cell-data/TileDB-SOMA'}), ('libtiledbsoma', {'home': 'http://tiledb.com', 'license': 'MIT', 'license_family': 'MIT', 'license_file': 'LICENSE', 'summary': 'TileDB-SOMA C++ library', 'description': 'SOMA - for "Stack Of Matrices, Annotated" - is a flexible, extensible, and open-source API enabling access to data in a variety of formats. The driving use case of SOMA is for single-cell data in the form of annotated matrices where observations are frequently cells and features are genes, proteins, or genomic regions.', 'doc_url': 'https://docs.tiledb.com/', 'dev_url': 'https://github.com/single-cell-data/TileDB-SOMA'}), ('r-tiledbsoma', {'home': 'http://tiledb.com', 'license': 'MIT', 'license_family': 'MIT', 'license_file': ['/home/wsl/mambaforge/conda-bld/tiledbsoma_1737647302077/_h_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/R/share/licenses/MIT', 'apis/r/LICENSE'], 'summary': 'TileDB-SOMA R API', 'description': 'R API for efficient storage and retrieval of single-cell data using TileDB', 'doc_url': 'https://docs.tiledb.com/', 'dev_url': 'https://github.com/single-cell-data/TileDB-SOMA/tree/main/apis/r'}), ('tiledbsoma-py', {'home': 'http://tiledb.com', 'license': 'MIT', 'license_family': 'MIT', 'license_file': 'LICENSE', 'summary': 'TileDB-SOMA Python API', 'description': 'Python API for efficient storage and retrieval of single-cell data using TileDB', 'doc_url': 'https://docs.tiledb.com/', 'dev_url': 'https://github.com/single-cell-data/TileDB-SOMA/tree/main/apis/python'})]
INFO:conda_smithy.configure_feedstock:Re-rendered with conda-build 24.11.2, conda-smithy 3.45.3, and conda-forge-pinning 2025.01.23.13.47.17
INFO:conda_smithy.configure_feedstock:No changes made. This feedstock is up-to-date.
```