### PR TITLE
tiledbsoma 1.15.6 pre-check, `main` branch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.5" %}
-{% set sha256 = "0642a1066140749ba02176d45ce260a3755868577c40123951942c058389df51" %}
+{% set version = "1.15.6" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,17 +16,17 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  # release-1.15 branch 2025-01-24
-#  git_rev: ceb4a3682663dfc74a346c91cc5bfa85a0b0674c
-#  git_depth: -1
-#  # hoping to be 1.15.5 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  # release-1.15 branch 2025-02-03
+  git_rev: c815e1b8d53fa8828a1dc1c259fa1f8d8e7cbaba
+  git_depth: -1
+  # hoping to be 1.15.6 <-- FILL IN HERE
 
 build:
   number: 0


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

https://github.com/single-cell-data/TileDB-SOMA/issues/3662