### PR TITLE
tiledbsoma 1.15.7, `py39cloud` branch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.6" %}
-{% set sha256 = "78ad7959cf2114c8e278f310a5add7ac8b04d97a6141284703755005691fe12d" %}
+{% set version = "1.15.7" %}
+{% set sha256 = "ecdcafc2cb83e392e1102fea11e910548bcacdb854b5bc365c96ef940fed0c3f" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

https://github.com/single-cell-data/TileDB-SOMA/issues/3662

[[sc-62929]](https://app.shortcut.com/tiledb-inc/story/62929/tiledbsoma-1-15-7)