### PR TITLE
Pre-check for 1.16.0 that supports C++20 (`py39cloud` branch)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/build-libtiledbsoma.sh
+++ b/recipe/build-libtiledbsoma.sh
@@ -2,6 +2,9 @@
 
 set -exo pipefail
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 mkdir libtiledbsoma-build && cd libtiledbsoma-build
 
 cmake \

--- a/recipe/build-r-tiledbsoma.sh
+++ b/recipe/build-r-tiledbsoma.sh
@@ -4,21 +4,28 @@ set -ex
 
 cd apis/r
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 export DISABLE_AUTOBREW=1
 
 # https://github.com/conda-forge/r-tiledb-feedstock/commit/29cb6816636e7b5b58545e1407a8f0c29ff9dc39
-if [[ $target_platform  == osx-64 ]]; then
+if [[ $target_platform == osx-* ]]; then
   export NN_CXX_ORIG=$CXX
   export NN_CC_ORIG=$CC
   export CXX=$RECIPE_DIR/cxx_wrap.sh
   export CC=$RECIPE_DIR/cc_wrap.sh
-  mkdir -p ~/.R
-  echo CC=$RECIPE_DIR/cc_wrap.sh > ~/.R/Makevars
-  echo CXX=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
-  echo CXX17=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
 fi
 
-export CXX17FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
+export CXX="$CXX -std=c++20 -fPIC"
+export CXX20="$CXX"
+
+mkdir -p ~/.R
+echo CC="$CC" > ~/.R/Makevars
+echo CXX="$CXX" >> ~/.R/Makevars
+echo CXX20="$CXX20" >> ~/.R/Makevars
+
+export CXX20FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
 
 # https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
 if [[ $target_platform == osx-*  ]]; then

--- a/recipe/build-tiledbsoma-py.sh
+++ b/recipe/build-tiledbsoma-py.sh
@@ -4,6 +4,9 @@ set -ex
 
 cd apis/python
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 echo
 echo "PKG_VERSION IS <<$PKG_VERSION>>"
 echo

--- a/recipe/cc_wrap.sh
+++ b/recipe/cc_wrap.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CC_ORIG $args -mmacosx-version-min=11.0
+$NN_CC_ORIG "$@" -mmacosx-version-min=13.3

--- a/recipe/cxx_wrap.sh
+++ b/recipe/cxx_wrap.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CXX_ORIG $args -mmacosx-version-min=11.0
+$NN_CXX_ORIG "$@" -mmacosx-version-min=13.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.8" %}
+{% set version = "1.16.0" %}
 {% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
@@ -23,10 +23,9 @@ package:
 # Pre-tag canary "will Conda be green if we release":
 source:
  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
- # main branch 2025-02-07; replace with commit for 1.15.x release with cpp20 support
- git_rev: 2105abc5165f034588b76b5cf9b8d59270ff5ad6
+ git_rev: dad714f7e09dbebe9105cebb3f11ad8d646d6c4c
  git_depth: -1
- # hoping to be 1.15.8 <-- FILL IN HERE
+ # hoping to be 1.16.0 <-- FILL IN HERE
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.7" %}
-{% set sha256 = "ecdcafc2cb83e392e1102fea11e910548bcacdb854b5bc365c96ef940fed0c3f" %}
+{% set version = "1.15.8" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,17 +16,17 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+# source:
+#   url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#   sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  # release-1.15 branch 2025-01-24
-#  git_rev: ceb4a3682663dfc74a346c91cc5bfa85a0b0674c
-#  git_depth: -1
-#  # hoping to be 1.15.5 <-- FILL IN HERE
+source:
+ git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+ # main branch 2025-02-07; replace with commit for 1.15.x release with cpp20 support
+ git_rev: 2105abc5165f034588b76b5cf9b8d59270ff5ad6
+ git_depth: -1
+ # hoping to be 1.15.8 <-- FILL IN HERE
 
 build:
   number: 0


### PR DESCRIPTION
Companion pre-check to #275, but applied to the py39cloud branch

```sh
git checkout main
cp .github/scripts/nightly/cpp20.patch /tmp/
git checkout py39cloud
git checkout -b jdb/pre-check-cpp20-py39cloud

patch -p1 < /tmp/cpp20.patch
## patching file recipe/build-libtiledbsoma.sh
## patching file recipe/build-r-tiledbsoma.sh
## patching file recipe/build-tiledbsoma-py.sh
## patching file recipe/cc_wrap.sh
## patching file recipe/conda_build_config.yaml
## Hunk #1 FAILED at 1.
## 1 out of 1 hunk FAILED -- saving rejects to file recipe/conda_build_config.yaml.rej
## patching file recipe/cxx_wrap.sh

# It's ok the patch to conda_build_config.yaml was rejected. This was an osx-specifc
# change, and the py39cloud branch only builds for linux-64
rm recipe/conda_build_config.yaml.orig recipe/conda_build_config.yaml.rej

git commit -a -m "Support C++20" --author="XanthosXanthopoulos <xanxanthopoulos@gmail.com>"

# updated recipe to pull from main branch and committed

conda smithy rerender --commit auto

# The nightly builds weren't edited in this branch since this is controlled on main
```

#3720 [[sc-63626]](https://app.shortcut.com/tiledb-inc/story/63626/tiledb-soma-1-16-0)