### PR TITLE
Limit to R 4.3 until TileDB-SOMA-R is tested with R 4.4 on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,3 +10,6 @@ channel_targets:
   - tiledb main
 channel_priority:
   - strict
+# Limit to R 4.3 until TileDB-SOMA-R is tested with R 4.4 on macOS
+r_base:
+  - 4.3


### PR DESCRIPTION
Closes #277

xref: https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/277#issuecomment-2666360359