### PR TITLE
Add R 4.4 builds for linux-64 and osx-64

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -39,6 +39,7 @@ python:
 - 3.9.* *_cpython
 r_base:
 - '4.3'
+- '4.4'
 spdlog:
 - '1.15'
 target_platform:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -41,6 +41,7 @@ python:
 - 3.9.* *_cpython
 r_base:
 - '4.3'
+- '4.4'
 spdlog:
 - '1.15'
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -10,7 +10,7 @@ channel_targets:
   - tiledb main
 channel_priority:
   - strict
-# Limit to R 4.3 until TileDB-SOMA-R is tested with R 4.4 on macOS
+# Limit osx-arm64 to R 4.3 until build error is fixed
 # Please see https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/279
-r_base:
-  - 4.3
+r_base:  # [osx and arm64]
+  - 4.3  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -201,8 +201,10 @@ outputs:
       commands:
         - $R -e "library('tiledbsoma')"
         - $R -e "tiledbsoma::show_package_versions()"
-        - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.dylib | grep -e libR -e libtiledb"  # [osx]
         - "ldd $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.so | grep -e libR -e libtiledb"  # [linux]
+        # r-base-feedstock updated SHLIB_EXT from .dylib to .so on macOS between R 4.3 and 4.4
+        - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.dylib | grep -e libR -e libtiledb"  # [osx and r_base == "4.3"]
+        - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.so    | grep -e libR -e libtiledb"  # [osx and r_base != "4.3"]
     about:
       home: http://tiledb.com
       license: MIT


### PR DESCRIPTION
The R 4.4 r-tiledbsoma build was already passing on linux-64, and the fix for the osx-64 looked straightforward.

Followup to #278. For more details see #279