### PR TITLE
tiledbsoma-1.16.0 pre-check, `py39cloud`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.7" %}
-{% set sha256 = "ecdcafc2cb83e392e1102fea11e910548bcacdb854b5bc365c96ef940fed0c3f" %}
+{% set version = "1.16.0" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -15,18 +15,18 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-# Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+## Post-tag real thing:
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  # release-1.15 branch 2025-01-24
-#  git_rev: ceb4a3682663dfc74a346c91cc5bfa85a0b0674c
-#  git_depth: -1
-#  # hoping to be 1.15.5 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  # release-1.15 branch 2025-01-24
+  git_rev: dad714f7e09dbebe9105cebb3f11ad8d646d6c4c
+  git_depth: -1
+  # hoping to be 1.16.0 <-- FILL IN HERE
 
 build:
   number: 0


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

@jdblischak I know I have more to do here following your notes earlier