### PR TITLE
tiledbsoma 1.16.0rc1 pre-check,`main` branch

### DIFF
--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -1,7 +1,7 @@
 MACOSX_DEPLOYMENT_TARGET:
 - '11.0'
 MACOSX_SDK_VERSION:
-- '11.0'
+- '13.3'
 c_compiler:
 - clang
 c_compiler_version:

--- a/.github/scripts/nightly/update-feedstock.sh
+++ b/.github/scripts/nightly/update-feedstock.sh
@@ -16,9 +16,5 @@ sed -i \
   s/"tiledb rc"/"tiledb nightlies"/ \
   recipe/conda_build_config.yaml
 
-# Apply patch from Xanthos to support C++20
-# https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/246
-patch -p1 < .github/scripts/nightly/cpp20.patch
-
 # Print differences
 git --no-pager diff conda-forge.yml recipe/conda_build_config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@
 
 # Rattler-build's artifacts are in `output` when not specifying anything.
 /output
+# Pixi's configuration
+.pixi

--- a/recipe/build-libtiledbsoma.sh
+++ b/recipe/build-libtiledbsoma.sh
@@ -13,6 +13,7 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DTILEDBSOMA_BUILD_CLI=OFF \
   -DTILEDBSOMA_ENABLE_TESTING=OFF \
+  -DSPDLOG_LINK_SHARED=ON \
   ../libtiledbsoma
 
 make -j ${CPU_COUNT}

--- a/recipe/build-libtiledbsoma.sh
+++ b/recipe/build-libtiledbsoma.sh
@@ -2,6 +2,9 @@
 
 set -exo pipefail
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 mkdir libtiledbsoma-build && cd libtiledbsoma-build
 
 cmake \

--- a/recipe/build-r-tiledbsoma.sh
+++ b/recipe/build-r-tiledbsoma.sh
@@ -4,21 +4,28 @@ set -ex
 
 cd apis/r
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 export DISABLE_AUTOBREW=1
 
 # https://github.com/conda-forge/r-tiledb-feedstock/commit/29cb6816636e7b5b58545e1407a8f0c29ff9dc39
-if [[ $target_platform  == osx-64 ]]; then
+if [[ $target_platform == osx-* ]]; then
   export NN_CXX_ORIG=$CXX
   export NN_CC_ORIG=$CC
   export CXX=$RECIPE_DIR/cxx_wrap.sh
   export CC=$RECIPE_DIR/cc_wrap.sh
-  mkdir -p ~/.R
-  echo CC=$RECIPE_DIR/cc_wrap.sh > ~/.R/Makevars
-  echo CXX=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
-  echo CXX17=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
 fi
 
-export CXX17FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
+export CXX="$CXX -std=c++20 -fPIC"
+export CXX20="$CXX"
+
+mkdir -p ~/.R
+echo CC="$CC" > ~/.R/Makevars
+echo CXX="$CXX" >> ~/.R/Makevars
+echo CXX20="$CXX20" >> ~/.R/Makevars
+
+export CXX20FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
 
 # https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
 if [[ $target_platform == osx-*  ]]; then

--- a/recipe/build-tiledbsoma-py.sh
+++ b/recipe/build-tiledbsoma-py.sh
@@ -4,6 +4,9 @@ set -ex
 
 cd apis/python
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 echo
 echo "PKG_VERSION IS <<$PKG_VERSION>>"
 echo

--- a/recipe/cc_wrap.sh
+++ b/recipe/cc_wrap.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CC_ORIG $args -mmacosx-version-min=11.0
+$NN_CC_ORIG "$@" -mmacosx-version-min=13.3

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,7 +1,7 @@
 # https://conda-forge.org/docs/maintainer/knowledge_base/#requiring-newer-macos-sdks
 # https://conda-forge.org/news/2024/03/24/stdlib-migration/
 MACOSX_SDK_VERSION:  # [osx and x86_64]
-  - 11.0            # [osx and x86_64]
+  - 13.3             # [osx and x86_64]
 c_stdlib_version:              # [osx and x86_64]
   - 11.0                       # [osx and x86_64]
 channel_sources:

--- a/recipe/cxx_wrap.sh
+++ b/recipe/cxx_wrap.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CXX_ORIG $args -mmacosx-version-min=11.0
+$NN_CXX_ORIG "$@" -mmacosx-version-min=13.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.7" %}
-{% set sha256 = "ecdcafc2cb83e392e1102fea11e910548bcacdb854b5bc365c96ef940fed0c3f" %}
+{% set version = "1.16.0rc1" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -15,18 +15,18 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-# Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+## Post-tag real thing:
+#source:
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  # release-1.15 branch 2025-01-24
-#  git_rev: ceb4a3682663dfc74a346c91cc5bfa85a0b0674c
-#  git_depth: -1
-#  # hoping to be 1.15.5 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  # release-1.16 branch 2025-03-05
+  git_rev: 1f12399f17297b75ed9205643e1719cabc9a961c
+  git_depth: -1
+  # hoping to be 1.16.0rc1 <-- FILL IN HERE
 
 build:
   number: 0


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

https://github.com/single-cell-data/TileDB-SOMA/issues/3720
[[sc-63626]](https://app.shortcut.com/tiledb-inc/story/63626/tiledb-soma-1-16-0)

Sibling of #284. Replays #275.