### PR TITLE
Bump somacore to 1.0.28 for nightly feedstock builds

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -20,4 +20,9 @@ sed -i \
   s/"sha256: .\+"/"git_rev: main\n  git_depth: -1"/ \
   recipe/meta.yaml
 
+# (Temporary) Bump somacore
+sed -i \
+  s/"somacore ==.\+"/"somacore ==1.0.28"/ \
+  recipe/meta.yaml
+
 git --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Closes #285 

xref: #217, https://github.com/single-cell-data/TileDB-SOMA/pull/3756