### PR TITLE
Build r-tiledbsoma 1.15.7 with R 4.4 for cloud deployment only

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -35,6 +35,7 @@ python:
 - 3.9.* *_cpython
 r_base:
 - '4.3'
+- '4.4'
 spdlog:
 - '1.11'
 target_platform:

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,8 @@
 /build_artifacts
 
 *.pyc
+
+# Rattler-build's artifacts are in `output` when not specifying anything.
+/output
+# Pixi's configuration
+.pixi


### PR DESCRIPTION
**summary:** We need r-tiledbsoma 1.15.7 built for R 4.4 to migrate the cloud notebook image to R 4.4

**details:**

* A customer has requested that we migrate the cloud R notebook image from 4.3 to 4.4, but the migration effort is currently blocked by conda solver errors (https://github.com/TileDB-Inc/TileDB-Cloud-JupyterHub/pull/824)
* Because conda-forge has started building its packages for R 4.4, adding support for R 4.4 in this feedstock required only a simple rerender (for more explanation see https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/284#discussion_r1983621378)
* I didn't bump the build number. We only want to update the new linux-64 conda binary for r-tiledbsoma built with R 4.4
* We are currently troubleshooting problems with the new R 4.4 builds on osx-64 and osx-arm64 (https://github.com/TileDB-Inc/tiledbsoma-feedstock/issues/279), but since the py39cloud branch only builds for linux-64, we don't need to be concerned with those errors