### PR TITLE
tiledbsoma 1.16.0, `py39cloud` branch

### DIFF
--- a/recipe/build-libtiledbsoma.sh
+++ b/recipe/build-libtiledbsoma.sh
@@ -2,6 +2,9 @@
 
 set -exo pipefail
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 mkdir libtiledbsoma-build && cd libtiledbsoma-build
 
 cmake \
@@ -10,6 +13,7 @@ cmake \
   -DCMAKE_BUILD_TYPE=Release \
   -DTILEDBSOMA_BUILD_CLI=OFF \
   -DTILEDBSOMA_ENABLE_TESTING=OFF \
+  -DSPDLOG_LINK_SHARED=ON \
   ../libtiledbsoma
 
 make -j ${CPU_COUNT}

--- a/recipe/build-r-tiledbsoma.sh
+++ b/recipe/build-r-tiledbsoma.sh
@@ -4,21 +4,28 @@ set -ex
 
 cd apis/r
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 export DISABLE_AUTOBREW=1
 
 # https://github.com/conda-forge/r-tiledb-feedstock/commit/29cb6816636e7b5b58545e1407a8f0c29ff9dc39
-if [[ $target_platform  == osx-64 ]]; then
+if [[ $target_platform == osx-* ]]; then
   export NN_CXX_ORIG=$CXX
   export NN_CC_ORIG=$CC
   export CXX=$RECIPE_DIR/cxx_wrap.sh
   export CC=$RECIPE_DIR/cc_wrap.sh
-  mkdir -p ~/.R
-  echo CC=$RECIPE_DIR/cc_wrap.sh > ~/.R/Makevars
-  echo CXX=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
-  echo CXX17=$RECIPE_DIR/cxx_wrap.sh >> ~/.R/Makevars
 fi
 
-export CXX17FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
+export CXX="$CXX -std=c++20 -fPIC"
+export CXX20="$CXX"
+
+mkdir -p ~/.R
+echo CC="$CC" > ~/.R/Makevars
+echo CXX="$CXX" >> ~/.R/Makevars
+echo CXX20="$CXX20" >> ~/.R/Makevars
+
+export CXX20FLAGS="-Wno-deprecated-declarations -Wno-deprecated"
 
 # https://conda-forge.org/docs/maintainer/knowledge_base/#newer-c-features-with-old-sdk
 if [[ $target_platform == osx-*  ]]; then

--- a/recipe/build-tiledbsoma-py.sh
+++ b/recipe/build-tiledbsoma-py.sh
@@ -4,6 +4,9 @@ set -ex
 
 cd apis/python
 
+# Clear default compiler flags
+export CXXFLAGS=${CXXFLAGS//"-fvisibility-inlines-hidden"/}
+
 echo
 echo "PKG_VERSION IS <<$PKG_VERSION>>"
 echo

--- a/recipe/cc_wrap.sh
+++ b/recipe/cc_wrap.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CC_ORIG $args -mmacosx-version-min=11.0
+$NN_CC_ORIG "$@" -mmacosx-version-min=13.3

--- a/recipe/cxx_wrap.sh
+++ b/recipe/cxx_wrap.sh
@@ -1,4 +1,3 @@
 #!/bin/sh
 
-args="${@##-mmacosx-version-min=10.9*}"
-$NN_CXX_ORIG $args -mmacosx-version-min=11.0
+$NN_CXX_ORIG "$@" -mmacosx-version-min=13.3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.16.0rc1" %}
-{% set sha256 = "tbd" %}
+{% set version = "1.16.0" %}
+{% set sha256 = "614f6d369f4c2d24f7556133c5f0b796e0196ebfa9fd0a95cb78f1f7f1206d8d" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,17 +16,17 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-# source:
-#   url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-#   sha256: {{ sha256 }}
-
-# Pre-tag canary "will Conda be green if we release":
 source:
-  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  # release-1.16 branch 2025-03-05
-  git_rev: 1f12399f17297b75ed9205643e1719cabc9a961c
-  git_depth: -1
-  # hoping to be 1.16.0rc1 <-- FILL IN HERE
+  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+## Pre-tag canary "will Conda be green if we release":
+#source:
+#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+#  # release-1.16 branch 2025-03-05
+#  git_rev: 1f12399f17297b75ed9205643e1719cabc9a961c
+#  git_depth: -1
+#  # hoping to be 1.16.0rc1 <-- FILL IN HERE
 
 build:
   number: 0
@@ -102,12 +102,13 @@ outputs:
         # Keep this in sync with TileDB-SOMA's somacore version requirement.
         - somacore ==1.0.28
         - scanpy >=1.9.2
-        # See TileDB-SOMA's apis/python/requirements_spatial.txt
-        - geopandas
-        - tifffile
-        - pillow
-        - spatialdata-io >=0.2.5
-        - xarray
+        # WIP -- see TileDB-SOMA's apis/python/requirements_spatial.txt
+        # Pending https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/280
+        # - geopandas
+        # - tifffile
+        # - pillow
+        # - spatialdata-io >=0.2.5
+        # - xarray
     test:
       imports:
         - tiledbsoma

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.15.7" %}
-{% set sha256 = "ecdcafc2cb83e392e1102fea11e910548bcacdb854b5bc365c96ef940fed0c3f" %}
+{% set version = "1.16.0rc1" %}
+{% set sha256 = "tbd" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -16,17 +16,17 @@ package:
   version: {{ version }}
 
 # Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+# source:
+#   url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#   sha256: {{ sha256 }}
 
 # Pre-tag canary "will Conda be green if we release":
-#source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  # release-1.15 branch 2025-01-24
-#  git_rev: ceb4a3682663dfc74a346c91cc5bfa85a0b0674c
-#  git_depth: -1
-#  # hoping to be 1.15.5 <-- FILL IN HERE
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  # release-1.16 branch 2025-03-05
+  git_rev: 1f12399f17297b75ed9205643e1719cabc9a961c
+  git_depth: -1
+  # hoping to be 1.16.0rc1 <-- FILL IN HERE
 
 build:
   number: 0
@@ -100,8 +100,14 @@ outputs:
         - numba >=0.58.1
         - attrs >=22.2
         # Keep this in sync with TileDB-SOMA's somacore version requirement.
-        - somacore ==1.0.26
+        - somacore ==1.0.28
         - scanpy >=1.9.2
+        # See TileDB-SOMA's apis/python/requirements_spatial.txt
+        - geopandas
+        - tifffile
+        - pillow
+        - spatialdata-io >=0.2.5
+        - xarray
     test:
       imports:
         - tiledbsoma


### PR DESCRIPTION
Following our [established procedure](https://github.com/single-cell-data/TileDB-SOMA/wiki/Branches-and-releases)

https://github.com/single-cell-data/TileDB-SOMA/issues/3720 [[sc-63626]](https://app.shortcut.com/tiledb-inc/story/63626/tiledb-soma-1-16-0)

SIbling: #288