### PR TITLE
Run R package tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -165,7 +165,7 @@ outputs:
         - r-base
         - r-r6
         - r-matrix
-        - r-bit64 >=4.6.0.1          # [build_platform != target_platform]
+        - r-bit64 >=4.6.0.1
         - r-rcppint64
         - r-tiledb >=0.31.0,<0.32
         - r-arrow
@@ -183,7 +183,7 @@ outputs:
         - r-base
         - r-r6
         - r-matrix
-        - r-bit64 >=4.6.0.1          # [build_platform != target_platform]
+        - r-bit64 >=4.6.0.1
         - r-tiledb >=0.31.0,<0.32
         - r-arrow
         - r-fs
@@ -198,6 +198,14 @@ outputs:
     test:
       requires:
         - cctools  # [osx]
+        - r-iterators
+        - r-itertools
+        - r-jsonlite
+        - r-seuratobject >= 4.1.0
+        - r-testthat >=3.0.0
+        - r-withr
+      source_files:
+        - apis/r/tests/
       commands:
         - $R -e "library('tiledbsoma')"
         - $R -e "tiledbsoma::show_package_versions()"
@@ -205,6 +213,8 @@ outputs:
         # r-base-feedstock updated SHLIB_EXT from .dylib to .so on macOS between R 4.3 and 4.4
         - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.dylib | grep -e libR -e libtiledb"  # [osx and r_base == "4.3"]
         - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.so    | grep -e libR -e libtiledb"  # [osx and r_base != "4.3"]
+        # Run testthat tests
+        - $R -e "testthat::test_file('apis/r/tests/testthat.R', stop_on_failure = TRUE)"
     about:
       home: http://tiledb.com
       license: MIT


### PR DESCRIPTION
This is a quality-of-life improvement to catch any potential problems with the R package well before on image testing. This can wait until we finish the more urgent 1.16.1 deployment.

I followed the official conda-forge guidance for [Running `testthat` tests](https://conda-forge.org/docs/maintainer/adding_pkgs/#running-testthat-tests). By installing all the optional dependencies except the big data packages (which I don't want to package for conda) and the bioconductor packages (I don't want to get the bioconda channel involved), we run the majority of the tests. And it only takes a little over 3 minutes, so for two R variants this only adds another 6-7 minutes to an already long build. Seems worth it to me.

```
# example test results on my fork for linux-64 SOMA 1.16.0 R 4.4

══ Results ═════════════════════════════════════════════════════════════════════
Duration: 201.6 s

── Skipped tests (14) ──────────────────────────────────────────────────────────
• {pbmc3k.sce} is not installed (2):
  'test-15-SingleCellExperimentIngest.R:3:3',
  'test-16-write-soma-resume.R:513:3'
• {pbmc3k.tiledb} is not installed (6): 'test-00-Blockwise.R:3:3',
  'test-00-Blockwise.R:127:3', 'test-09-SOMAOpen.R:2:3',
  'test-10-SOMAArrayReader-Iterated.R:3:3',
  'test-10-SOMAArrayReader-Iterated.R:91:3',
  'test-10-SOMAArrayReader-Iterated.R:166:3'
• {SingleCellExperiment} is not installed (5): 'test-15-SCEOutgest.R:3:3',
  'test-15-SCEOutgest.R:201:3', 'test-15-SCEOutgest.R:258:3',
  'test-15-SCEOutgest.R:336:3', 'test-15-SingleCellExperimentIngest.R:70:3'
• {SummarizedExperiment} is not installed (1):
  'test-14-SummarizedExperimentIngest.R:3:3'

[ FAIL 0 | WARN 0 | SKIP 14 | PASS 3736 ]
 Done!
```