### PR TITLE
Run R package tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -145,7 +145,7 @@ outputs:
         - r-base
         - r-r6
         - r-matrix
-        - r-bit64
+        - r-bit64 >=4.6.0.1
         - r-rcppint64
         - r-tiledb >=0.31.0,<0.32
         - r-arrow
@@ -163,7 +163,7 @@ outputs:
         - r-base
         - r-r6
         - r-matrix
-        - r-bit64
+        - r-bit64 >=4.6.0.1
         - r-tiledb >=0.31.0,<0.32
         - r-arrow
         - r-fs
@@ -176,10 +176,21 @@ outputs:
         - r-rlang
         - r-nanoarrow
     test:
+      requires:
+        - r-iterators
+        - r-itertools
+        - r-jsonlite
+        - r-seuratobject >= 4.1.0
+        - r-testthat >=3.0.0
+        - r-withr
+      source_files:
+        - apis/r/tests/
       commands:
         - $R -e "library('tiledbsoma')"
         - $R -e "tiledbsoma::show_package_versions()"
         - "ldd $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.so | grep -e libR -e libtiledb"  # [linux]
+        # Run testthat tests
+        - $R -e "testthat::test_file('apis/r/tests/testthat.R', stop_on_failure = TRUE)"
     about:
       home: http://tiledb.com
       license: MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,11 +70,6 @@ outputs:
       build:
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
-        - python                                 # [build_platform != target_platform]
-        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
-        - pybind11                               # [build_platform != target_platform]
-        - pyarrow                                # [build_platform != target_platform]
-        - numpy                                  # [build_platform != target_platform]
       host:
         - python
         - pip
@@ -145,22 +140,6 @@ outputs:
         - {{ compiler('cxx') }}
         - {{ stdlib("c") }}
         - pkg-config
-        # required for cross-compilation
-        - cross-r-base {{ r_base }}  # [build_platform != target_platform]
-        - r-rcppspdlog >=0.0.19      # [build_platform != target_platform]
-        - r-matrix                   # [build_platform != target_platform]
-        - r-bit64                    # [build_platform != target_platform]
-        - r-rcppint64                # [build_platform != target_platform]
-        - r-tiledb >=0.31.0,<0.32    # [build_platform != target_platform]
-        - r-arrow                    # [build_platform != target_platform]
-        - r-fs                       # [build_platform != target_platform]
-        - r-glue                     # [build_platform != target_platform]
-        - r-urltools                 # [build_platform != target_platform]
-        - r-rcpp                     # [build_platform != target_platform]
-        - r-dplyr                    # [build_platform != target_platform]
-        - r-data.table               # [build_platform != target_platform]
-        - r-rlang                    # [build_platform != target_platform]
-        - r-nanoarrow                # [build_platform != target_platform]
       host:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
         - r-base
@@ -197,12 +176,9 @@ outputs:
         - r-rlang
         - r-nanoarrow
     test:
-      requires:
-        - cctools  # [osx]
       commands:
         - $R -e "library('tiledbsoma')"
         - $R -e "tiledbsoma::show_package_versions()"
-        - "otool -L $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.dylib | grep -e libR -e libtiledb"  # [osx]
         - "ldd $PREFIX/lib/R/library/tiledbsoma/libs/tiledbsoma.so | grep -e libR -e libtiledb"  # [linux]
     about:
       home: http://tiledb.com


### PR DESCRIPTION
Companion to #294

Does the following:

* Declutters the recipe by removing the osx-only items (this py39cloud variant is only built for linux-64)
* Adds the lower bound `r-bit64 >=4.6.0.1` introduced in SOMA 1.16.0
* Runs the R package {testthat} tests to detect potential problems early