### PR TITLE
Install spatial requirements for import tests for py>=310

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -101,19 +101,22 @@ outputs:
         # Keep this in sync with TileDB-SOMA's somacore version requirement.
         - somacore ==1.0.28
         - scanpy >=1.9.2
-        # WIP -- see TileDB-SOMA's apis/python/requirements_spatial.txt
-        # Pending https://github.com/TileDB-Inc/tiledbsoma-feedstock/pull/280
-        # - geopandas
-        # - tifffile
-        # - pillow
-        # - spatialdata-io >=0.2.5
-        # - xarray
     test:
       imports:
         - tiledbsoma
+        - tiledbsoma.io          # [py>=310]
+        - tiledbsoma.io.spatial  # [py>=310]
       requires:
         - pip
         - tiledb-py >=0.33.0,<0.34.0
+        # Spatial requirements
+        # https://github.com/single-cell-data/TileDB-SOMA/blob/main/apis/python/requirements_spatial.txt
+        - geopandas            # [py>=310]
+        - tifffile             # [py>=310]
+        - pillow               # [py>=310]
+        - spatialdata >=0.2.5  # [py>=310]
+        - xarray               # [py>=310]
+        - dask <=2024.11.2     # [py>=310]
       commands:
         - python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())'
         # See also:


### PR DESCRIPTION
The goal is to be able to test `import tiledbsoma.io.spatial` in the feedstock builds.

Notes:

* The CI may fail due to a conda solver error. I'm still working on getting all the spatial requirements updated in conda-forge
* For now I am limiting this to python >= 3.10 since most of the recent releases of the spatial packages no longer support python 3.9. However, we may be able to relax it to include python 3.9 since this feedstock build can be more flexible with the lower bound of fsspec compared to our cloud env
* I put the spatial requirements in the `test` section instead of `run`. This is to match the behavior upstream. The [spatial requirements](https://github.com/single-cell-data/TileDB-SOMA/blob/1.16.1/apis/python/requirements_spatial.txt) are [optional](https://github.com/single-cell-data/TileDB-SOMA/blob/d1a8259cbb1d0242d27520ea9ba7226ec752edd7/apis/python/setup.py#L359). I'm open to debating this though. My personal preference is to match the behavior of the upstream package, but am willing to be convinced otherwise. One potential issue I see going forward is that if the tiledbsoma-py from the `tiledb` channel requires the spatial packages, but the conda-forge binary doesn't, the conda solver might choose to install the conda-forge version since it is easier to solve the env
* I removed the comment about PR 280. It has subsequently been merged. Also, it was enabling R 4.4 builds, so it isn't blocking installation of the spatial packages