### PR TITLE
[ci skip] Install new Python requirement more-itertools in nightly build

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -20,4 +20,11 @@ sed -i \
   s/"sha256: .\+"/"git_rev: main\n  git_depth: -1"/ \
   recipe/meta.yaml
 
+# (Temporary) Add new requirement more-itertools
+# https://github.com/single-cell-data/TileDB-SOMA/pull/3865
+# https://anaconda.org/conda-forge/more-itertools
+sed -i \
+  s/"- pandas"/"- pandas\n        - more-itertools"/ \
+  recipe/meta.yaml
+
 git --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Closes #302 

In the next update PR, `more-itertools` needs to be added as a run requirement, and this temporary code can be removed.