### PR TITLE
[ci skip] Update nightly build post-1.16.2

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -20,11 +20,4 @@ sed -i \
   s/"sha256: .\+"/"git_rev: main\n  git_depth: -1"/ \
   recipe/meta.yaml
 
-# (Temporary) Add new requirement more-itertools
-# https://github.com/single-cell-data/TileDB-SOMA/pull/3865
-# https://anaconda.org/conda-forge/more-itertools
-sed -i \
-  s/"- pandas"/"- pandas\n        - more-itertools"/ \
-  recipe/meta.yaml
-
 git --no-pager diff recipe/meta.yaml

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,8 +17,8 @@ package:
 
 ## Post-tag real thing:
 source:
- url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
- sha256: {{ sha256 }}
+  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
 
 ## Pre-tag canary "will Conda be green if we release":
 #source:


### PR DESCRIPTION
Closes #309 

This PR does two things to update the nightly build:

* It restores the standard 2 space indentation of the source section of the recipe. Our nightly build is mostly a series of `sed` commands, so the exact spacing is required. The reason the nightly setup build started failing on Friday is because the 1.16.2 update PR used a single space for indentation (#309) 
* Removed the temporary code to add the new dependency `more-itertools`, since that was added in 1.16.2

There is no point in running the Azure builds for this PR, hence the `[ci skip]`. I confirmed this will fix the nightly setup job via a [manual run on my fork](https://github.com/jdblischak/tiledbsoma-feedstock/actions/runs/14840820457).