### PR TITLE
Store the conda build_artifacts dir as an Azure pipeline artifact

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,6 +12,7 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+        SHORT_CONFIG: linux_64_
   timeoutInMinutes: 360
   variables: {}
 
@@ -41,3 +42,32 @@ jobs:
     displayName: Run docker build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+  - script: |
+        export CI=azure
+        export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+        export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+        export CONDA_BLD_DIR=build_artifacts
+        export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+        # Archive everything in CONDA_BLD_DIR except environments
+        export BLD_ARTIFACT_PREFIX=conda_artifacts
+        if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+          # Archive the CONDA_BLD_DIR environments only when the job fails
+          export ENV_ARTIFACT_PREFIX=conda_envs
+        fi
+        ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -11,9 +11,11 @@ jobs:
       osx_64_:
         CONFIG: osx_64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_64_
       osx_arm64_:
         CONFIG: osx_arm64_
         UPLOAD_PACKAGES: 'True'
+        SHORT_CONFIG: osx_arm64_
   timeoutInMinutes: 360
   variables: {}
 
@@ -37,3 +39,32 @@ jobs:
     displayName: Run OSX build
     env:
       BINSTAR_TOKEN: $(BINSTAR_TOKEN)
+  - script: |
+      export CI=azure
+      export CI_RUN_ID=$(build.BuildNumber).$(system.JobAttempt)
+      export FEEDSTOCK_NAME=$(basename ${BUILD_REPOSITORY_NAME})
+      export CONDA_BLD_DIR=/Users/runner/miniforge3/conda-bld
+      export ARTIFACT_STAGING_DIR="$(Build.ArtifactStagingDirectory)"
+      # Archive everything in CONDA_BLD_DIR except environments
+      export BLD_ARTIFACT_PREFIX=conda_artifacts
+      if [[ "$AGENT_JOBSTATUS" == "Failed" ]]; then
+        # Archive the CONDA_BLD_DIR environments only when the job fails
+        export ENV_ARTIFACT_PREFIX=conda_envs
+      fi
+      ./.scripts/create_conda_build_artifacts.sh
+    displayName: Prepare conda build artifacts
+    condition: succeededOrFailed()
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build artifacts
+    condition: not(eq(variables.BLD_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(BLD_ARTIFACT_PATH)
+      artifactName: $(BLD_ARTIFACT_NAME)
+
+  - task: PublishPipelineArtifact@1
+    displayName: Store conda build environment artifacts
+    condition: not(eq(variables.ENV_ARTIFACT_PATH, ''))
+    inputs:
+      targetPath: $(ENV_ARTIFACT_PATH)
+      artifactName: $(ENV_ARTIFACT_NAME)

--- a/.scripts/create_conda_build_artifacts.sh
+++ b/.scripts/create_conda_build_artifacts.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# INPUTS (environment variables that need to be set before calling this script):
+#
+# CI (azure/github_actions/UNSET)
+# CI_RUN_ID (unique identifier for the CI job run)
+# FEEDSTOCK_NAME
+# CONFIG (build matrix configuration string)
+# SHORT_CONFIG (uniquely-shortened configuration string)
+# CONDA_BLD_DIR (path to the conda-bld directory)
+# ARTIFACT_STAGING_DIR (use working directory if unset)
+# BLD_ARTIFACT_PREFIX (prefix for the conda build artifact name, skip if unset)
+# ENV_ARTIFACT_PREFIX (prefix for the conda build environments artifact name, skip if unset)
+
+# OUTPUTS
+#
+# BLD_ARTIFACT_NAME
+# BLD_ARTIFACT_PATH
+# ENV_ARTIFACT_NAME
+# ENV_ARTIFACT_PATH
+
+source .scripts/logging_utils.sh
+
+# DON'T do set -x, because it results in double echo-ing pipeline commands
+# and that might end up inserting extraneous quotation marks in output variables
+set -e
+
+# Check that the conda-build directory exists
+if [ ! -d "$CONDA_BLD_DIR" ]; then
+    echo "conda-build directory does not exist"
+    exit 1
+fi
+
+# Set staging dir to the working dir, in Windows style if applicable
+if [[ -z "${ARTIFACT_STAGING_DIR}" ]]; then
+    if pwd -W; then
+        ARTIFACT_STAGING_DIR=$(pwd -W)
+    else
+        ARTIFACT_STAGING_DIR=$PWD
+    fi
+fi
+echo "ARTIFACT_STAGING_DIR: $ARTIFACT_STAGING_DIR"
+
+FEEDSTOCK_ROOT=$(cd "$(dirname "$0")/.."; pwd;)
+if [ -z ${FEEDSTOCK_NAME} ]; then
+    export FEEDSTOCK_NAME=$(basename ${FEEDSTOCK_ROOT})
+fi
+
+# Set a unique ID for the artifact(s), specialized for this particular job run
+ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+if [[ ${#ARTIFACT_UNIQUE_ID} -gt 80 ]]; then
+    ARTIFACT_UNIQUE_ID="${CI_RUN_ID}_${SHORT_CONFIG}"
+fi
+echo "ARTIFACT_UNIQUE_ID: $ARTIFACT_UNIQUE_ID"
+
+# Set a descriptive ID for the archive(s), specialized for this particular job run
+ARCHIVE_UNIQUE_ID="${CI_RUN_ID}_${CONFIG}"
+
+# Make the build artifact zip
+if [[ ! -z "$BLD_ARTIFACT_PREFIX" ]]; then
+    export BLD_ARTIFACT_NAME="${BLD_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export BLD_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${BLD_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build directory" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$BLD_ARTIFACT_PATH" "$CONDA_BLD_DIR" '-xr!.git/' '-xr!_*_env*/' '-xr!*_cache/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$BLD_ARTIFACT_PATH" . -x '*.git/*' '*_*_env*/*' '*_cache/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build directory" ) 2> /dev/null
+
+    echo "BLD_ARTIFACT_NAME: $BLD_ARTIFACT_NAME"
+    echo "BLD_ARTIFACT_PATH: $BLD_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_NAME]$BLD_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=BLD_ARTIFACT_PATH]$BLD_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "BLD_ARTIFACT_NAME=$BLD_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "BLD_ARTIFACT_PATH=$BLD_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+    fi
+fi
+
+# Make the environments artifact zip
+if [[ ! -z "$ENV_ARTIFACT_PREFIX" ]]; then
+    export ENV_ARTIFACT_NAME="${ENV_ARTIFACT_PREFIX}_${ARTIFACT_UNIQUE_ID}"
+    export ENV_ARTIFACT_PATH="${ARTIFACT_STAGING_DIR}/${FEEDSTOCK_NAME}_${ENV_ARTIFACT_PREFIX}_${ARCHIVE_UNIQUE_ID}.zip"
+
+    ( startgroup "Archive conda build environments" ) 2> /dev/null
+
+    # Try 7z and fall back to zip if it fails (for cross-platform use)
+    if ! 7z a "$ENV_ARTIFACT_PATH" -r "$CONDA_BLD_DIR"/'_*_env*/' -bb; then
+        pushd "$CONDA_BLD_DIR"
+        zip -r -y -T "$ENV_ARTIFACT_PATH" . -i '*_*_env*/*'
+        popd
+    fi
+
+    ( endgroup "Archive conda build environments" ) 2> /dev/null
+
+    echo "ENV_ARTIFACT_NAME: $ENV_ARTIFACT_NAME"
+    echo "ENV_ARTIFACT_PATH: $ENV_ARTIFACT_PATH"
+
+    if [[ "$CI" == "azure" ]]; then
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_NAME]$ENV_ARTIFACT_NAME"
+        echo "##vso[task.setVariable variable=ENV_ARTIFACT_PATH]$ENV_ARTIFACT_PATH"
+    elif [[ "$CI" == "github_actions" ]]; then
+        echo "ENV_ARTIFACT_NAME=$ENV_ARTIFACT_NAME" >> $GITHUB_OUTPUT
+        echo "ENV_ARTIFACT_PATH=$ENV_ARTIFACT_PATH" >> $GITHUB_OUTPUT
+    fi
+fi

--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -11,3 +11,4 @@ azure:
   build_id: 43
   user_or_org: TileDB-Inc
   project_name: CI
+  store_build_artifacts: True


### PR DESCRIPTION
I configured [`conda-forge.yml`](https://conda-forge.org/docs/maintainer/conda_forge_yml/#azure) to [upload the built conda binaries as Azure pipeline artifacts](https://conda.discourse.group/t/are-built-packages-saved-as-artifacts-when-a-pr-is-tested/934/2). Here are example artifacts from a run on my [fork](https://dev.azure.com/jdblischak/feedstock-builds/_build/results?buildId=1251&view=artifacts&pathAsName=false&type=publishedArtifacts).

This should help with future troubleshooting, because the whole `build_artifacts/` directory is uploaded even if the build fails at some step (`condition: succeededOrFailed()`).

The only unknown for me is how long these artifacts are stored. It's almost 30 MB of artifacts per run, which will add up. Hopefully they are auto-deleted similar to the build logs themselves. If not, someone with admin access to our TileDB-Inc Azure account may need to set a retention policy or manually delete them occasionally.