### PR TITLE
TileDB-SOMA 1.17.0, `py39cloud` branch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "1.16.2" %}
-{% set sha256 = "73deebfb0904e04da52ffdba7fd789797a8369b9ca8de95b6dbc62e0428d6904" %}
+{% set version = "1.17.0" %}
+{% set sha256 = "TBD" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -15,20 +15,20 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-# Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-  patches:
-  - remove-header.patch
-
-## Pre-tag canary "will Conda be green if we release":
+## Post-tag real thing:
 #source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  # release-1.16 branch 2025-03-05
-#  git_rev: 1f12399f17297b75ed9205643e1719cabc9a961c
-#  git_depth: -1
-#  # hoping to be 1.16.0rc0 <-- FILL IN HERE
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
+#  patches:
+#  - remove-header.patch
+
+# Pre-tag canary "will Conda be green if we release":
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  # release-1.16 branch 2025-03-05
+  git_rev: 9ba88ae46b3b74e3bf865ec4aacb0e1701174afe
+  git_depth: -1
+  # hoping to be 1.17.0rc0 <-- FILL IN HERE
 
 build:
   number: 0
@@ -48,7 +48,7 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.27.0,<2.28
+        - tiledb >=2.28.0,<2.29
         - spdlog
         - fmt
     about:
@@ -112,7 +112,7 @@ outputs:
         - tiledbsoma
       requires:
         - pip
-        - tiledb-py >=0.33.0,<0.34.0
+        - tiledb-py >=0.34.0,<0.35.0
       commands:
         - python -c 'import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())'
         # See also:
@@ -151,7 +151,7 @@ outputs:
         - r-matrix
         - r-bit64 >=4.6.0.1
         - r-rcppint64
-        - r-tiledb >=0.31.0,<0.32
+        - r-tiledb >=0.32.0,<0.33
         - r-arrow
         - r-fs
         - r-glue
@@ -168,7 +168,7 @@ outputs:
         - r-r6
         - r-matrix
         - r-bit64 >=4.6.0.1
-        - r-tiledb >=0.31.0,<0.32
+        - r-tiledb >=0.32.0,<0.33
         - r-arrow
         - r-fs
         - r-glue

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,6 +28,8 @@ source:
   # release-1.16 branch 2025-03-05
   git_rev: 9ba88ae46b3b74e3bf865ec4aacb0e1701174afe
   git_depth: -1
+  patches:
+  - remove-header.patch
   # hoping to be 1.17.0rc0 <-- FILL IN HERE
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
 {% set version = "1.17.0" %}
-{% set sha256 = "TBD" %}
+{% set sha256 = "c39be937059bdc6cf10a90dea847a28871f7b229fb102328374aaa40ed10e6a2" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -15,22 +15,22 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-## Post-tag real thing:
-#source:
-#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-#  sha256: {{ sha256 }}
-#  patches:
-#  - remove-header.patch
-
-# Pre-tag canary "will Conda be green if we release":
+# Post-tag real thing:
 source:
-  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  # release-1.16 branch 2025-03-05
-  git_rev: 9ba88ae46b3b74e3bf865ec4aacb0e1701174afe
-  git_depth: -1
+  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
   patches:
   - remove-header.patch
-  # hoping to be 1.17.0rc0 <-- FILL IN HERE
+
+## Pre-tag canary "will Conda be green if we release":
+#source:
+#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+#  # release-1.16 branch 2025-03-05
+#  git_rev: 9ba88ae46b3b74e3bf865ec4aacb0e1701174afe
+#  git_depth: -1
+#  patches:
+#  - remove-header.patch
+#  # hoping to be 1.17.0rc0 <-- FILL IN HERE
 
 build:
   number: 0


### PR DESCRIPTION
Update TileDB-SOMA to release 1.17.0.