### PR TITLE
[ci skip] Bump nightly build to use 2.28 stack

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -20,4 +20,15 @@ sed -i \
   s/"sha256: .\+"/"git_rev: main\n  git_depth: -1"/ \
   recipe/meta.yaml
 
+# (Temporary) Bump to 2.28 stack
+sed -i \
+  s/"tiledb >=2.27.0,<2.28"/"tiledb >=2.28.0,<2.29"/ \
+  recipe/meta.yaml
+sed -i \
+  s/"tiledb-py >=0.33.0,<0.34.0"/"tiledb-py >=0.34.0,<0.35.0"/ \
+  recipe/meta.yaml
+sed -i \
+  s/"r-tiledb >=0.31.0,<0.32"/"r-tiledb >=0.32.0,<0.33"/ \
+  recipe/meta.yaml
+
 git --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Closes #316 

The main branch of TileDB-SOMA targets tiledb 2.28. R enforces its minimum required version, so the builds are failing. This PR updates the nightly feedstock build to use the tiledb 2.28 stack. Once 1.17.0 is merged, this temporary code can be deleted.

As a test on my fork, I am running last night's setup with the 2.28 requirements (https://github.com/jdblischak/tiledbsoma-feedstock/commit/4d41578880d4ddaba90b7c7c4c4de94ca4b114f5)