### PR TITLE
[ci skip] Bump somacore to 1.0.29 for nightly feedstock builds

### DIFF
--- a/.github/scripts/nightly/update-recipe.sh
+++ b/.github/scripts/nightly/update-recipe.sh
@@ -20,4 +20,9 @@ sed -i \
   s/"sha256: .\+"/"git_rev: main\n  git_depth: -1"/ \
   recipe/meta.yaml
 
+# (Temporary) Bump somacore
+sed -i \
+  s/"somacore ==.\+"/"somacore ==1.0.29"/ \
+  recipe/meta.yaml
+
 git --no-pager diff recipe/meta.yaml


### PR DESCRIPTION
Closes #323

xref: #286