### PR TITLE
TileDB-SOMA 2.1.0 cloud release

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
 {% set version = "2.1.0" %}
-{% set sha256 = "TBD" %}
+{% set sha256 = "be810667130a3bb86ee40adff7592458c69f9336ee701c25856c5957b318c407" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -15,17 +15,17 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-## Post-tag real thing:
-#source:
-#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-#  sha256: {{ sha256 }}
-
-# Pre-tag canary "will Conda be green if we release":
+# Post-tag real thing:
 source:
-  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  # release 2.1.0rc0
-  git_rev: 8af224955354e965b1922e12ea5690310475af3c
-  git_depth: -1
+  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+## Pre-tag canary "will Conda be green if we release":
+#source:
+#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+#  # release 2.1.0rc0
+#  git_rev: 8af224955354e965b1922e12ea5690310475af3c
+#  git_depth: -1
 
 build:
   number: 0


### PR DESCRIPTION
Cloud release for TileDB-SOMA 2.1.0.