### PR TITLE
TileDB-SOMA 2.1.2 release [py39cloud]

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,7 +45,7 @@ outputs:
         - cmake
         - make  # [not win]
       host:
-        - tiledb >=2.29.0,<2.30
+        - tiledb ==2.29.2
         - spdlog
         - fmt
     about:


### PR DESCRIPTION
Update feedstock for 2.1.2 release.