### PR TITLE
TileDB-SOMA 2.2.0 release (cloud)

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
 {% set version = "2.2.0" %}
-{% set sha256 = "tbd" %}
+{% set sha256 = "30dbc6206bf3710eff177340ce27e90608ee1ce10c6559ffc9f585346780514d" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -15,17 +15,17 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-## Post-tag real thing:
-#source:
-#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-#  sha256: {{ sha256 }}
-
-# Pre-tag canary "will Conda be green if we release":
+# Post-tag real thing:
 source:
-  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  # release 2.2.0rc0
-  git_rev: a2348992a3a2ff6a453e995a946ef6eb201e8b94
-  git_depth: -1
+  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+## Pre-tag canary "will Conda be green if we release":
+#source:
+#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+#  # release 2.2.0rc0
+#  git_rev: a2348992a3a2ff6a453e995a946ef6eb201e8b94
+#  git_depth: -1
 
 build:
   number: 0


### PR DESCRIPTION
Update cloud branch for TileDB-SOMA release 2.2.0rc0.