### PR TITLE
TileDB-SOMA Release 2.3.0 (py39cloud)

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -32,8 +32,8 @@ pyarrow:
 python:
 - 3.9.* *_cpython
 r_base:
+- '4.3'
 - '4.4'
-- '4.5'
 spdlog:
 - '1.11'
 target_platform:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -32,8 +32,8 @@ pyarrow:
 python:
 - 3.9.* *_cpython
 r_base:
-- '4.3'
 - '4.4'
+- '4.5'
 spdlog:
 - '1.11'
 target_platform:

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -18,3 +18,6 @@ python_impl:
   - cpython
 is_python_min:
   - true
+r_base:
+  - 4.3
+  - 4.4

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,17 +15,17 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-# Post-tag real thing:
-source:
-  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-  sha256: {{ sha256 }}
-
-## Pre-tag canary "will Conda be green if we release":
+## Post-tag real thing:
 #source:
-#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-#  # release 2.2.0rc0
-#  git_rev: a2348992a3a2ff6a453e995a946ef6eb201e8b94
-#  git_depth: -1
+#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+#  sha256: {{ sha256 }}
+
+# Pre-tag canary "will Conda be green if we release":
+source:
+  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+  # release 2.2.0rc0
+  git_rev: da72c648b3058e8d93d42b345c37193762ccdb81
+  git_depth: -1
 
 build:
   number: 0
@@ -85,7 +85,7 @@ outputs:
       run:
         - {{ pin_compatible('numpy', lower_bound='1.16', upper_bound='1.27') }}
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
-        - pandas
+        - pandas <=3.0.0
         - pyarrow
         - python
         - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "tiledbsoma" %}
-{% set version = "2.2.0" %}
-{% set sha256 = "30dbc6206bf3710eff177340ce27e90608ee1ce10c6559ffc9f585346780514d" %}
+{% set version = "2.3.0" %}
+{% set sha256 = "d9d2844ceb9863f00f1ae2e0cfe6554150ee04ce7791fc87ef5f27a00d91dd13" %}
 # This is the SHA256 of
 #   TileDB-SOMA-i.j.k.tar.gz
 # from
@@ -15,17 +15,17 @@ package:
   name: {{ name }}
   version: {{ version }}
 
-## Post-tag real thing:
-#source:
-#  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
-#  sha256: {{ sha256 }}
-
-# Pre-tag canary "will Conda be green if we release":
+# Post-tag real thing:
 source:
-  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
-  # release 2.2.0rc0
-  git_rev: aac88138d12a5fb87ed2601500fdab103ba8a8a0
-  git_depth: -1
+  url: https://github.com/single-cell-data/TileDB-SOMA/archive/{{ version }}.tar.gz
+  sha256: {{ sha256 }}
+
+## Pre-tag canary "will Conda be green if we release":
+#source:
+#  git_url: https://github.com/single-cell-data/TileDB-SOMA.git
+#  # release 2.2.0rc0
+#  git_rev: aac88138d12a5fb87ed2601500fdab103ba8a8a0
+#  git_depth: -1
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -24,7 +24,7 @@ package:
 source:
   git_url: https://github.com/single-cell-data/TileDB-SOMA.git
   # release 2.2.0rc0
-  git_rev: da72c648b3058e8d93d42b345c37193762ccdb81
+  git_rev: aac88138d12a5fb87ed2601500fdab103ba8a8a0
   git_depth: -1
 
 build:


### PR DESCRIPTION
Update for TileDB-SOMA release 2.3.0.