### PR TITLE
Fix pandas to be strictly less than 3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ source:
 #  git_depth: -1
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or linux32 or py2k]
 # Important: set this back to 0 on a new release
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -89,7 +89,7 @@ outputs:
         - pyarrow
       run:
         - {{ pin_subpackage('libtiledbsoma', exact=True) }}
-        - pandas <=3.0.0
+        - pandas <3.0.0
         - pyarrow
         - python
         - scipy


### PR DESCRIPTION
Fix a typo in the TileDB-SOMA 2.3.0 release.