### PR TITLE
Reduce nightly SOMA feedstock builds to Mon-Thurs nights

### DIFF
--- a/.github/workflows/nightly-azure-status.yml
+++ b/.github/workflows/nightly-azure-status.yml
@@ -4,8 +4,9 @@
 name: nightly-azure-status
 on:
   schedule:
-     # https://crontab.guru/#0_11_*_*_*
-     - cron: "0 11 * * *" # Every day at 11 AM UTC (6 AM EST; 7 AM EDT)
+    # 11 AM UTC Tues-Fri (6 AM EST; 7 AM EDT Tues-Fri)
+    # https://crontab.guru/#0_11_*_*_2-5
+    - cron: "0 11 * * 2-5"
   workflow_dispatch:
 jobs:
   nightly-azure-status:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,9 @@ on:
     paths:
       - '.github/workflows/nightly.yml'
   schedule:
-     - cron: "27 1 * * *" # Every night at 1:27 AM UTC (8:27 PM EST; 9:27 PM EDT)
+    # 1:27 AM UTC Tues-Fri (8:27 PM EST; 9:27 PM EDT Mon-Thurs)
+    # https://crontab.guru/#27_1_*_*_2-5
+    - cron: "27 1 * * 2-5"
   workflow_dispatch:
 jobs:
   nightly:


### PR DESCRIPTION
This PR limits the nightly feedstock builds to four evenings per week, Monday through Thursday nights. This focuses the nightly builds when they are most useful (when upstream SOMA is most actively developed, and when I most likely to be available to troubleshoot). And they still happen often enough to catch problems with the conda-forge ecosystem (eg changes in the versions of globally pinned software).

xref: https://github.com/TileDB-Inc/conda-forge-nightly-controller/pull/256, https://github.com/TileDB-Inc/centralized-tiledb-nightlies/commit/af71837a63cf3f5aa7144e6f1ee1058164f97dc3

Explanation of the CRON schedules:

* The nightly feedstock builds will be triggered to run every Monday through Thursday night. This is already the following day in UTC, hence `2-5` for Tuesday through Friday
* The workflow to check the status of the nightly Azure build runs the following morning, so also Tuesday through Friday