### PR TITLE
[ci skip] Migrate GitHub Actions to Node24

### DIFF
--- a/.github/workflows/nightly-azure-status.yml
+++ b/.github/workflows/nightly-azure-status.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check Azure Status API
         if: github.repository_owner == 'TileDB-Inc' # do not run on forks
         env:
@@ -30,7 +30,7 @@ jobs:
     needs: nightly-azure-status
     if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Open Issue
         uses: TileDB-Inc/github-actions/open-issue@main
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Update recipe source to use Git repo
         run: bash .github/scripts/nightly/update-recipe.sh
       - name: Update feedstock
@@ -29,7 +29,7 @@ jobs:
       - name: Add and commit
         run: bash .github/scripts/nightly/add-and-commit.sh
       - name: Install conda-smithy to rerender
-        uses: mamba-org/setup-micromamba@v1
+        uses: mamba-org/setup-micromamba@v3
         with:
           environment-name: env
           create-args: conda-smithy
@@ -49,7 +49,7 @@ jobs:
     needs: nightly
     if: ( failure() || cancelled() ) && github.repository_owner == 'TileDB-Inc' && github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Open Issue
         uses: TileDB-Inc/github-actions/open-issue@main
         with:


### PR DESCRIPTION
These workflows support our nightly feedstock build infrastructure.